### PR TITLE
Add clean URLs to the site

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4263,8 +4263,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4285,14 +4284,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4307,20 +4304,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4437,8 +4431,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4450,7 +4443,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4465,7 +4457,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4473,14 +4464,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4499,7 +4488,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4580,8 +4568,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4593,7 +4580,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4679,8 +4665,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4716,7 +4701,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4736,7 +4720,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4780,14 +4763,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -10589,6 +10570,11 @@
           }
         }
       }
+    },
+    "vuepress-plugin-clean-urls": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/vuepress-plugin-clean-urls/-/vuepress-plugin-clean-urls-1.0.3.tgz",
+      "integrity": "sha512-fdsK2e+cTm8mVRm2S8TcnlijPZTX31v61sqUx+4Xiq+KqB05UQlpKI1lz1gte59L8VeDoOE0JjoGXpDFTFlqcQ=="
     },
     "vuepress-plugin-container": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
 		"iso-639-1": "^2.1.0",
 		"lodash.groupby": "^4.6.0",
 		"lodash.sortby": "^4.7.0",
+		"vuepress-plugin-clean-urls": "^1.0.3",
 		"vuepress-plugin-container": "^2.0.2"
 	}
 }

--- a/src/.vuepress/config/plugins.js
+++ b/src/.vuepress/config/plugins.js
@@ -17,10 +17,6 @@ module.exports = [
 		}
 	],
 	[
-		'clean-urls',
-		{
-			normalSuffix: '',
-			indexSuffix: ''
-		}
+		'clean-urls'
 	]
 ];

--- a/src/.vuepress/config/plugins.js
+++ b/src/.vuepress/config/plugins.js
@@ -15,5 +15,12 @@ module.exports = [
 			before: info => `<details><summary>${info}</summary>\n`,
 			after: '</details>\n'
 		}
+	],
+	[
+		'clean-urls',
+		{
+			normalSuffix: '',
+			indexSuffix: ''
+		}
 	]
 ];


### PR DESCRIPTION
This takes advantage over the Vuepress plugin "clean-urls", basically it makes URLs go from:
`https://tachiyomi.org/help/faq/extensions.html#how-do-i-allow-third-party-installations` to:
`https://tachiyomi.org/help/faq/extensions#how-do-i-allow-third-party-installations` for example.

Basically it just hides the `.html` extension.