### PR TITLE
Add source migration and duplicates guide info

### DIFF
--- a/src/help/faq/application.md
+++ b/src/help/faq/application.md
@@ -14,6 +14,12 @@ If you want to see how many chapters you have downloaded for all manga on My Lib
 
 The URL to the cover has changed. To fix this, refresh the metadata of your library in `Settings > Advanced`.
 
+### How do I ignore chapters from certain scanlator groups?
+
+Every now and then you find a manga that is translated by more than one group, because of this you get multiple releases for every chapter in the manga.
+
+To automatically skip a translation group while reading, go to the manga's chapter list and click on the three dots in the upper right hand corner. From there, click on Sorting mode and select By chapter number. You won't see any changes but, when you start reading you'll automatically skip the duplicate releases.
+
 ## Reader
 
 ### Why are some images not displayed?

--- a/src/help/guides/source-migration.md
+++ b/src/help/guides/source-migration.md
@@ -4,7 +4,14 @@ lang: en-US
 ---
 
 # Source migration
-:construction: :construction_worker_man: W.I.P. Description, help us improve through [here](https://github.com/tachiyomiorg/website/edit/master/src/help/guides/source-migration.md)!
 
-## Guide?
-:construction: :construction_worker_man: W.I.P.
+::: tip
+This is useful when the source you are using is taken down or there are no plans to fix it, but it exists on other sources.
+:::
+
+Source migration transfers all the data from a manga entry over to the other source.
+
+1. Go to the top right corner of the library and press the overflow menu (3 dot menu), and tap "Source Migration".
+1. Scroll down to the source you're transferring from and tap select.
+1. Scroll down to the title you're transferring and tap that. Tachiyomi will do a global search of all the sources you have installed and enabled. Change the search query if you're not able to find the manga you want.
+1. Once you find the manga you want, you just tap it, check the parts of the manga data you want to transfer over, and you're done.


### PR DESCRIPTION
Addresses #10 by moving some leftover content from https://github.com/inorichi/tachiyomi/wiki/Guides

