### PR TITLE
Add custom .vue component for Material Icons

### DIFF
--- a/src/.vuepress/components/MaterialIcon.vue
+++ b/src/.vuepress/components/MaterialIcon.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div class="material-holder">
     <i class="material-icons">{{ iconName }}</i>
   </div>
 </template>
@@ -13,7 +13,7 @@ export default {
 <style scoped>
 @import url("https://fonts.googleapis.com/icon?family=Material+Icons");
 
-div {
+.material-holder {
     color: #476582;
     background-color: rgba(27,31,35,0.05);    
     width: fit-content;

--- a/src/.vuepress/components/MaterialIcon.vue
+++ b/src/.vuepress/components/MaterialIcon.vue
@@ -1,0 +1,26 @@
+<template>
+  <div>
+    <i class="material-icons">{{ iconName }}</i>
+  </div>
+</template>
+
+<script>
+export default {
+  props: ['iconName']
+}
+</script>
+
+<style scoped>
+@import url("https://fonts.googleapis.com/icon?family=Material+Icons");
+
+div {
+    color: #476582;
+    background-color: rgba(27,31,35,0.05);    
+    width: fit-content;
+    display: inline;
+}
+
+.material-icons {
+    font-size: 18px;
+}
+</style>

--- a/src/.vuepress/enhanceApp.js
+++ b/src/.vuepress/enhanceApp.js
@@ -3,7 +3,6 @@ import './styles/index.scss';
 import { library } from '@fortawesome/fontawesome-svg-core';
 import { faDownload } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
-import MaterialIcon from './components/MaterialIcon.vue'
 
 library.add(faDownload);
 
@@ -14,5 +13,4 @@ export default ({
 	siteData // site metadata
 }) => {
 	Vue.component('font-awesome-icon', FontAwesomeIcon);
-	Vue.component(MaterialIcon);
 };

--- a/src/.vuepress/enhanceApp.js
+++ b/src/.vuepress/enhanceApp.js
@@ -3,6 +3,7 @@ import './styles/index.scss';
 import { library } from '@fortawesome/fontawesome-svg-core';
 import { faDownload } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import MaterialIcon from './components/MaterialIcon.vue'
 
 library.add(faDownload);
 
@@ -13,4 +14,5 @@ export default ({
 	siteData // site metadata
 }) => {
 	Vue.component('font-awesome-icon', FontAwesomeIcon);
+	Vue.component(MaterialIcon);
 };

--- a/src/help/guides/categories.md
+++ b/src/help/guides/categories.md
@@ -75,7 +75,7 @@ You can delete a Category in `My Library` > triple dots (`⋮`) > `Edit categori
 
 ## Add Manga to Category
 
-You can add Manga to a Category by long pressing on the one you want to add. Then press the square looking icon (in the middle between pencil and three dots). Thereafter select which category you want it in. You can also add multiple manga to a category by selecting them when you see the square looking icon.
+You can add Manga to a Category by long pressing on the one you want to add. Then press the label icon (<MaterialIcon icon-name="label"/>) (in the middle between pencil and three dots). Thereafter select which category you want it in. You can also add multiple manga to a category by selecting them when you see the label icon (<MaterialIcon icon-name="label"/>).
 
 ::: tip
 You can also add Manga to multiple Categories by selecting the categories you want to have it in
@@ -94,7 +94,7 @@ You can also add Manga to multiple Categories by selecting the categories you wa
 
 ## Remove Manga from Category
 
-You can remove Manga from a Category by long pressing on the one you want. Then press the square looking icon. Thereafter deselect which category you want to remove it from. You can also remove multiple manga from a category by selecting them when you see the square looking icon.
+You can remove Manga from a Category by long pressing on the one you want. Then press the label icon (<MaterialIcon icon-name="label"/>). Thereafter deselect which category you want to remove it from. You can also remove multiple manga from a category by selecting them when you see the label icon (<MaterialIcon icon-name="label"/>).
 ::: tip
 You can remove a Manga to multiple Categories by selecting the categories you want to have it in
 :::


### PR DESCRIPTION
This adds the ability to use icons from https://material.io/resources/icons/ which helps to explain what a users should press.

Preview:
![image](https://user-images.githubusercontent.com/6576096/65960990-f11be100-e455-11e9-9190-c87c8397f433.png)

Usage:
`<MaterialIcon icon-name="replace-this"/>`