### PR TITLE
Add code to prevent big SVG on load

### DIFF
--- a/src/.vuepress/theme/components/Home.vue
+++ b/src/.vuepress/theme/components/Home.vue
@@ -163,6 +163,11 @@ export default {
 				margin-left: 0.5rem;
 			}
 
+			svg {
+				height: 1em;
+				width: 1em;
+			}
+
 			& + .action-button {
 				margin-left: 0.5rem;
 			}


### PR DESCRIPTION
Added code to the download icon SVG so it doesn't load in the wrong proportions.

This is now fixed:
![image](https://user-images.githubusercontent.com/10836780/66261567-1c912980-e7d0-11e9-89d9-430252590cb6.png)
