### PR TITLE
Update home and extension icons to MaterialDesignIcons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -842,32 +842,6 @@
         "to-fast-properties": "^2.0.0"
       }
     },
-    "@fortawesome/fontawesome-common-types": {
-      "version": "0.2.25",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.25.tgz",
-      "integrity": "sha512-3RuZPDuuPELd7RXtUqTCfed14fcny9UiPOkdr2i+cYxBoTOfQgxcDoq77fHiiHcgWuo1LoBUpvGxFF1H/y7s3Q=="
-    },
-    "@fortawesome/fontawesome-svg-core": {
-      "version": "1.2.25",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.25.tgz",
-      "integrity": "sha512-MotKnn53JKqbkLQiwcZSBJVYtTgIKFbh7B8+kd05TSnfKYPFmjKKI59o2fpz5t0Hzl35vVGU6+N4twoOpZUrqA==",
-      "requires": {
-        "@fortawesome/fontawesome-common-types": "^0.2.25"
-      }
-    },
-    "@fortawesome/free-solid-svg-icons": {
-      "version": "5.11.2",
-      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.11.2.tgz",
-      "integrity": "sha512-zBue4i0PAZJUXOmLBBvM7L0O7wmsDC8dFv9IhpW5QL4kT9xhhVUsYg/LX1+5KaukWq4/cbDcKT+RT1aRe543sg==",
-      "requires": {
-        "@fortawesome/fontawesome-common-types": "^0.2.25"
-      }
-    },
-    "@fortawesome/vue-fontawesome": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/@fortawesome/vue-fontawesome/-/vue-fontawesome-0.1.7.tgz",
-      "integrity": "sha512-YCw2Q2m4fxzyFsPOH3uDYMoJztTD+pT+AAyse4LFpbdrBg+r8ueaVT8BFnXEjrGwMDJJeXrwJ5AOC6q/JWBI4w=="
-    },
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",

--- a/package.json
+++ b/package.json
@@ -18,9 +18,6 @@
 		"vuepress": "^1.1.0"
 	},
 	"dependencies": {
-		"@fortawesome/fontawesome-svg-core": "^1.2.25",
-		"@fortawesome/free-solid-svg-icons": "^5.11.2",
-		"@fortawesome/vue-fontawesome": "^0.1.7",
 		"axios": "^0.19.0",
 		"iso-639-1": "^2.1.0",
 		"lodash.groupby": "^4.6.0",

--- a/src/.vuepress/components/ExtensionList.vue
+++ b/src/.vuepress/components/ExtensionList.vue
@@ -18,7 +18,7 @@
 					class="button"
 					title="Download APK"
 					download>
-					<font-awesome-icon icon="download" />
+					<MaterialIcon icon-name="get_app"/>
 					<span>Download</span>
 				</a>
 			</div>
@@ -99,7 +99,11 @@ export default {
 			text-decoration: none !important;
 		}
 
-		svg + span {
+		i {
+			color: #fff;
+		}
+
+		div.material-holder + span {
 			margin-left: 0.25rem;
 		}
 	}

--- a/src/.vuepress/enhanceApp.js
+++ b/src/.vuepress/enhanceApp.js
@@ -1,16 +1,8 @@
 import './styles/index.scss';
 
-import { library } from '@fortawesome/fontawesome-svg-core';
-import { faDownload } from '@fortawesome/free-solid-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
-
-library.add(faDownload);
-
 export default ({
 	Vue, // the version of Vue being used in the VuePress app
 	options, // the options for the root Vue instance
 	router, // the router instance for the app
 	siteData // site metadata
-}) => {
-	Vue.component('font-awesome-icon', FontAwesomeIcon);
-};
+}) => {};

--- a/src/.vuepress/theme/components/Home.vue
+++ b/src/.vuepress/theme/components/Home.vue
@@ -24,7 +24,7 @@
 					title="Download latest release"
 					download
 				>
-					<font-awesome-icon icon="download" />
+					<MaterialIcon icon-name="get_app"/>
 					<span>Download {{ tagName || 'vX.X.X' }}</span>
 				</a>
 
@@ -159,13 +159,12 @@ export default {
 				}
 			}
 
-			svg + span {
+			div.material-holder + span {
 				margin-left: 0.5rem;
 			}
 
-			svg {
-				height: 1em;
-				width: 1em;
+			i {
+				color: #fff;
 			}
 
 			& + .action-button {

--- a/src/.vuepress/theme/components/Home.vue
+++ b/src/.vuepress/theme/components/Home.vue
@@ -24,8 +24,10 @@
 					title="Download latest release"
 					download
 				>
-					<MaterialIcon icon-name="get_app"/>
-					<span>Download {{ tagName || 'vX.X.X' }}</span>
+					<div class="icon-holder">
+						<MaterialIcon icon-name="get_app"/>
+						<span>Download {{ tagName || 'vX.X.X' }}</span>
+					</div>
 				</a>
 
 				<NavLink
@@ -136,7 +138,7 @@ export default {
 
 		.action-button {
 			display: inline-block;
-			font-size: 1.2rem;
+			font-size: 1.125rem;
 			color: #fff;
 			background-color: $accentColor;
 			padding: 0.8rem 1.6rem;
@@ -159,12 +161,24 @@ export default {
 				}
 			}
 
-			div.material-holder + span {
-				margin-left: 0.5rem;
+			.icon-holder {
+				display: flex;
+				justify-content: center;
+				align-items: center;
+			}
+
+			.material-holder + span {
+				margin-left: .375em;
+			}
+
+			.download-get_app {
+				margin-left: .188em;
+				margin-right: .250em;
 			}
 
 			i {
 				color: #fff;
+				max-width: 2em;
 			}
 
 			& + .action-button {

--- a/src/.vuepress/theme/components/Home.vue
+++ b/src/.vuepress/theme/components/Home.vue
@@ -26,7 +26,7 @@
 				>
 					<div class="icon-holder">
 						<MaterialIcon icon-name="get_app"/>
-						<span>Download {{ tagName || 'vX.X.X' }}</span>
+						<span>Download {{ tagName || 'v0.8.4' }}</span>
 					</div>
 				</a>
 


### PR DESCRIPTION
Removes previous FontAwesome icons and replaces them with MaterialDesignIcons for consistency.