### PR TITLE
Move CSS imports to head

### DIFF
--- a/src/.vuepress/components/DownloadButtons.vue
+++ b/src/.vuepress/components/DownloadButtons.vue
@@ -24,8 +24,6 @@
 </template>
 
 <style scoped lang="scss">
-@import url("https://fonts.googleapis.com/icon?family=Material+Icons");
-@import url("https://fonts.googleapis.com/css?family=Open+Sans");
 * {
 	font-family: "Open Sans", Roboto, -apple-system, BlinkMacSystemFont, "Segoe UI", Oxygen, Ubuntu, Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
 }

--- a/src/.vuepress/components/MaterialIcon.vue
+++ b/src/.vuepress/components/MaterialIcon.vue
@@ -32,10 +32,8 @@ export default {
 </script>
 
 <style scoped>
-@import url("https://fonts.googleapis.com/icon?family=Material+Icons");
-@import url("https://cdn.materialdesignicons.com/4.4.95/css/materialdesignicons.min.css");
-
 .material-holder {
+	font-family: 'Material Design Icons', 'Material Icons', sans-serif;
 	color: #476582;
 	margin: 0;
 	font-size: 0.85em;

--- a/src/.vuepress/config.js
+++ b/src/.vuepress/config.js
@@ -3,6 +3,11 @@ module.exports = {
 	description: 'Free and open source manga reader for Android.',
 	dest: './public',
 	head: [
+		['link', { rel: "preconnect", href: 'https://cdn.materialdesignicons.com/', crossorigin:""} , ''],
+		['link', { rel: "preconnect", href: 'https://fonts.gstatic.com', crossorigin:""} , ''],
+		['link', { rel: "stylesheet", href: 'https://cdn.materialdesignicons.com/4.4.95/css/materialdesignicons.min.css', crossorigin:""} , ''],
+		['link', { rel: "stylesheet", href: 'https://fonts.googleapis.com/css?family=Open+Sans'} , ''],
+		['link', { rel: "stylesheet", href: 'https://fonts.googleapis.com/icon?family=Material+Icons'} , ''],
 		['script', { src: 'https://unpkg.com/flickity@2/dist/flickity.pkgd.min.js'} , ''],
 		['link', { rel: "stylesheet", type: "text/css", href: 'https://unpkg.com/flickity@2/dist/flickity.min.css'} , ''],
 	],


### PR DESCRIPTION
This moves all `@import url()` to `<head>`. Compared to the current site it doesn't change anything except for cleaning up `@import url()`