### PR TITLE
Makes download link point to github release if github is slow, fails …

### DIFF
--- a/src/.vuepress/theme/components/Home.vue
+++ b/src/.vuepress/theme/components/Home.vue
@@ -22,7 +22,7 @@
 					rel="noopener noreferrer"
 					:href="browserDownloadUrl || 'https://github.com/inorichi/tachiyomi/releases/latest'"
 					title="Download latest release"
-					:download="browserDownloadUrl ? true : false"
+					:download="browserDownloadUrl ? '' : null"
 				>
 					<font-awesome-icon icon="download" />
 					<span>Download {{ tagName || 'vX.X.X' }}</span>

--- a/src/.vuepress/theme/components/Home.vue
+++ b/src/.vuepress/theme/components/Home.vue
@@ -20,9 +20,9 @@
 				<a
 					class="action-button"
 					rel="noopener noreferrer"
-					:href="browserDownloadUrl || null"
+					:href="browserDownloadUrl || 'https://github.com/inorichi/tachiyomi/releases/latest'"
 					title="Download latest release"
-					download
+					:download="browserDownloadUrl ? true : false"
 				>
 					<font-awesome-icon icon="download" />
 					<span>Download {{ tagName || 'vX.X.X' }}</span>


### PR DESCRIPTION
Ensures download is available if js is blocked, some part is down, or latency is extreme.

Just kinda adds a default state.