### PR TITLE
Update URL

### DIFF
--- a/src/help/faq/application.md
+++ b/src/help/faq/application.md
@@ -101,7 +101,7 @@ Read more [here](/help/guides/general/#language)
 ### What happened to the F-Droid version?
 F-Droid is no longer an officially supported option. Both the stable and dev builds now include an autoupdate mechanism.
 
-An unofficial F-Droid repo is available at [Efreak/tachiyomi-extensions](https://github.com/Efreak/tachiyomi-extensions).
+An unofficial F-Droid repo is available at [tachi.efreakbnc.net](https://tachi.efreakbnc.net).
 
 ### Why do I get a `App not installed` error when installing?
 You may encounter this if you're installing an official build over an existing F-Droid build due to differing signatures.


### PR DESCRIPTION
tachi.efreakbnc.net is kept up to date, while efreak/Tachiyomi-Extensions is only occasionally available as a website (though the repo is up to date and can be used via proxies like rawgit2)