### PR TITLE
Change index download buttons

### DIFF
--- a/src/.vuepress/styles/index.scss
+++ b/src/.vuepress/styles/index.scss
@@ -115,3 +115,11 @@
 	-ms-user-select: none;
 	user-select: none;
 }
+
+a.nav-link.action-button.secondary {
+	margin-top: .5em;
+	font-family: "Open Sans", Roboto, -apple-system, BlinkMacSystemFont, "Segoe UI", Oxygen, Ubuntu, Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+	font-size: 1.125em;
+	border-radius: .3125em;
+	border-bottom: none;
+}

--- a/src/.vuepress/theme/components/Home.vue
+++ b/src/.vuepress/theme/components/Home.vue
@@ -17,16 +17,8 @@
 				class="action"
 				v-if="data.actionText && data.actionLink"
 			>
-				<a
-					class="action-button"
-					rel="noopener noreferrer"
-					:href="browserDownloadUrl || 'https://github.com/inorichi/tachiyomi/releases/latest'"
-					title="Download latest release"
-					:download="browserDownloadUrl ? '' : null"
-				>
-					<font-awesome-icon icon="download" />
-					<span>Download {{ tagName || 'vX.X.X' }}</span>
-				</a>
+				<DownloadButtons
+				/>
 
 				<NavLink
 					class="action-button secondary"

--- a/src/README.md
+++ b/src/README.md
@@ -2,7 +2,7 @@
 home: true
 lang: en-US
 heroImage: /assets/media/hero.png
-actionText: Get Started →
+actionText: Get started →
 actionLink: /help/guides/getting-started
 features:
     - title: Extensions


### PR DESCRIPTION
Change the **Stable** download button on the index/front-page to the dual download buttons featured on the "Getting started" page.

![image](https://user-images.githubusercontent.com/10836780/72010504-425b1e00-3258-11ea-8968-0a75e4620204.png)