### PR TITLE
Track download modal clicks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,21 +13,33 @@
 				"@babel/highlight": "^7.0.0"
 			}
 		},
-		"@babel/core": {
-			"version": "7.7.7",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.7.7.tgz",
-			"integrity": "sha512-jlSjuj/7z138NLZALxVgrx13AOtqip42ATZP7+kYl53GvDV6+4dCek1mVUo8z8c8Xnw/mx2q3d9HWh3griuesQ==",
+		"@babel/compat-data": {
+			"version": "7.8.6",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.8.6.tgz",
+			"integrity": "sha512-CurCIKPTkS25Mb8mz267vU95vy+TyUpnctEX2lV33xWNmHAfjruztgiPBbXZRh3xZZy1CYvGx6XfxyTVS+sk7Q==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "^7.5.5",
-				"@babel/generator": "^7.7.7",
-				"@babel/helpers": "^7.7.4",
-				"@babel/parser": "^7.7.7",
-				"@babel/template": "^7.7.4",
-				"@babel/traverse": "^7.7.4",
-				"@babel/types": "^7.7.4",
+				"browserslist": "^4.8.5",
+				"invariant": "^2.2.4",
+				"semver": "^5.5.0"
+			}
+		},
+		"@babel/core": {
+			"version": "7.8.6",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.8.6.tgz",
+			"integrity": "sha512-Sheg7yEJD51YHAvLEV/7Uvw95AeWqYPL3Vk3zGujJKIhJ+8oLw2ALaf3hbucILhKsgSoADOvtKRJuNVdcJkOrg==",
+			"dev": true,
+			"requires": {
+				"@babel/code-frame": "^7.8.3",
+				"@babel/generator": "^7.8.6",
+				"@babel/helpers": "^7.8.4",
+				"@babel/parser": "^7.8.6",
+				"@babel/template": "^7.8.6",
+				"@babel/traverse": "^7.8.6",
+				"@babel/types": "^7.8.6",
 				"convert-source-map": "^1.7.0",
 				"debug": "^4.1.0",
+				"gensync": "^1.0.0-beta.1",
 				"json5": "^2.1.0",
 				"lodash": "^4.17.13",
 				"resolve": "^1.3.2",
@@ -35,6 +47,132 @@
 				"source-map": "^0.5.0"
 			},
 			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.8.3",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+					"integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.8.3"
+					}
+				},
+				"@babel/generator": {
+					"version": "7.8.6",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.6.tgz",
+					"integrity": "sha512-4bpOR5ZBz+wWcMeVtcf7FbjcFzCp+817z2/gHNncIRcM9MmKzUhtWCYAq27RAfUrAFwb+OCG1s9WEaVxfi6cjg==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.8.6",
+						"jsesc": "^2.5.1",
+						"lodash": "^4.17.13",
+						"source-map": "^0.5.0"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.8.3",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
+					"integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.8.3",
+						"@babel/template": "^7.8.3",
+						"@babel/types": "^7.8.3"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.8.3",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
+					"integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.8.3"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.8.3",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
+					"integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.8.3"
+					}
+				},
+				"@babel/highlight": {
+					"version": "7.8.3",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
+					"integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.0.0",
+						"esutils": "^2.0.2",
+						"js-tokens": "^4.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.8.6",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.6.tgz",
+					"integrity": "sha512-trGNYSfwq5s0SgM1BMEB8hX3NDmO7EP2wsDGDexiaKMB92BaRpS+qZfpkMqUBhcsOTBwNy9B/jieo4ad/t/z2g==",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.8.6",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.6.tgz",
+					"integrity": "sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.8.3",
+						"@babel/parser": "^7.8.6",
+						"@babel/types": "^7.8.6"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.8.6",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.6.tgz",
+					"integrity": "sha512-2B8l0db/DPi8iinITKuo7cbPznLCEk0kCxDoB9/N6gGNg/gxOXiR/IcymAFPiBwk5w6TtQ27w4wpElgp9btR9A==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.8.3",
+						"@babel/generator": "^7.8.6",
+						"@babel/helper-function-name": "^7.8.3",
+						"@babel/helper-split-export-declaration": "^7.8.3",
+						"@babel/parser": "^7.8.6",
+						"@babel/types": "^7.8.6",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0",
+						"lodash": "^4.17.13"
+					}
+				},
+				"@babel/types": {
+					"version": "7.8.6",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.6.tgz",
+					"integrity": "sha512-wqz7pgWMIrht3gquyEFPVXeXCti72Rm8ep9b5tQKz9Yg9LzJA3HxosF1SB3Kc81KD1A3XBkkVYtJvCKS2Z/QrA==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
 				"debug": {
 					"version": "4.1.1",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -64,6 +202,15 @@
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
 					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
 					"dev": true
+				},
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
 				}
 			}
 		},
@@ -88,78 +235,641 @@
 			}
 		},
 		"@babel/helper-annotate-as-pure": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.7.4.tgz",
-			"integrity": "sha512-2BQmQgECKzYKFPpiycoF9tlb5HA4lrVyAmLLVK177EcQAqjVLciUb2/R+n1boQ9y5ENV3uz2ZqiNw7QMBBw1Og==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.8.3.tgz",
+			"integrity": "sha512-6o+mJrZBxOoEX77Ezv9zwW7WV8DdluouRKNY/IR5u/YTMuKHgugHOzYWlYvYLpLA9nPsQCAAASpCIbjI9Mv+Uw==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.7.4"
+				"@babel/types": "^7.8.3"
+			},
+			"dependencies": {
+				"@babel/types": {
+					"version": "7.8.6",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.6.tgz",
+					"integrity": "sha512-wqz7pgWMIrht3gquyEFPVXeXCti72Rm8ep9b5tQKz9Yg9LzJA3HxosF1SB3Kc81KD1A3XBkkVYtJvCKS2Z/QrA==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				}
 			}
 		},
 		"@babel/helper-builder-binary-assignment-operator-visitor": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.7.4.tgz",
-			"integrity": "sha512-Biq/d/WtvfftWZ9Uf39hbPBYDUo986m5Bb4zhkeYDGUllF43D+nUe5M6Vuo6/8JDK/0YX/uBdeoQpyaNhNugZQ==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.8.3.tgz",
+			"integrity": "sha512-5eFOm2SyFPK4Rh3XMMRDjN7lBH0orh3ss0g3rTYZnBQ+r6YPj7lgDyCvPphynHvUrobJmeMignBr6Acw9mAPlw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-explode-assignable-expression": "^7.7.4",
-				"@babel/types": "^7.7.4"
+				"@babel/helper-explode-assignable-expression": "^7.8.3",
+				"@babel/types": "^7.8.3"
+			},
+			"dependencies": {
+				"@babel/types": {
+					"version": "7.8.6",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.6.tgz",
+					"integrity": "sha512-wqz7pgWMIrht3gquyEFPVXeXCti72Rm8ep9b5tQKz9Yg9LzJA3HxosF1SB3Kc81KD1A3XBkkVYtJvCKS2Z/QrA==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				}
 			}
 		},
 		"@babel/helper-call-delegate": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.7.4.tgz",
-			"integrity": "sha512-8JH9/B7J7tCYJ2PpWVpw9JhPuEVHztagNVuQAFBVFYluRMlpG7F1CgKEgGeL6KFqcsIa92ZYVj6DSc0XwmN1ZA==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.8.3.tgz",
+			"integrity": "sha512-6Q05px0Eb+N4/GTyKPPvnkig7Lylw+QzihMpws9iiZQv7ZImf84ZsZpQH7QoWN4n4tm81SnSzPgHw2qtO0Zf3A==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-hoist-variables": "^7.7.4",
-				"@babel/traverse": "^7.7.4",
-				"@babel/types": "^7.7.4"
+				"@babel/helper-hoist-variables": "^7.8.3",
+				"@babel/traverse": "^7.8.3",
+				"@babel/types": "^7.8.3"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.8.3",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+					"integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.8.3"
+					}
+				},
+				"@babel/generator": {
+					"version": "7.8.6",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.6.tgz",
+					"integrity": "sha512-4bpOR5ZBz+wWcMeVtcf7FbjcFzCp+817z2/gHNncIRcM9MmKzUhtWCYAq27RAfUrAFwb+OCG1s9WEaVxfi6cjg==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.8.6",
+						"jsesc": "^2.5.1",
+						"lodash": "^4.17.13",
+						"source-map": "^0.5.0"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.8.3",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
+					"integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.8.3",
+						"@babel/template": "^7.8.3",
+						"@babel/types": "^7.8.3"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.8.3",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
+					"integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.8.3"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.8.3",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
+					"integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.8.3"
+					}
+				},
+				"@babel/highlight": {
+					"version": "7.8.3",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
+					"integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.0.0",
+						"esutils": "^2.0.2",
+						"js-tokens": "^4.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.8.6",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.6.tgz",
+					"integrity": "sha512-trGNYSfwq5s0SgM1BMEB8hX3NDmO7EP2wsDGDexiaKMB92BaRpS+qZfpkMqUBhcsOTBwNy9B/jieo4ad/t/z2g==",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.8.6",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.6.tgz",
+					"integrity": "sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.8.3",
+						"@babel/parser": "^7.8.6",
+						"@babel/types": "^7.8.6"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.8.6",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.6.tgz",
+					"integrity": "sha512-2B8l0db/DPi8iinITKuo7cbPznLCEk0kCxDoB9/N6gGNg/gxOXiR/IcymAFPiBwk5w6TtQ27w4wpElgp9btR9A==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.8.3",
+						"@babel/generator": "^7.8.6",
+						"@babel/helper-function-name": "^7.8.3",
+						"@babel/helper-split-export-declaration": "^7.8.3",
+						"@babel/parser": "^7.8.6",
+						"@babel/types": "^7.8.6",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0",
+						"lodash": "^4.17.13"
+					}
+				},
+				"@babel/types": {
+					"version": "7.8.6",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.6.tgz",
+					"integrity": "sha512-wqz7pgWMIrht3gquyEFPVXeXCti72Rm8ep9b5tQKz9Yg9LzJA3HxosF1SB3Kc81KD1A3XBkkVYtJvCKS2Z/QrA==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"ms": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+					"dev": true
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
+			}
+		},
+		"@babel/helper-compilation-targets": {
+			"version": "7.8.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.8.6.tgz",
+			"integrity": "sha512-UrJdk27hKVJSnibFcUWYLkCL0ZywTUoot8yii1lsHJcvwrypagmYKjHLMWivQPm4s6GdyygCL8fiH5EYLxhQwQ==",
+			"dev": true,
+			"requires": {
+				"@babel/compat-data": "^7.8.6",
+				"browserslist": "^4.8.5",
+				"invariant": "^2.2.4",
+				"levenary": "^1.1.1",
+				"semver": "^5.5.0"
 			}
 		},
 		"@babel/helper-create-class-features-plugin": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.7.4.tgz",
-			"integrity": "sha512-l+OnKACG4uiDHQ/aJT8dwpR+LhCJALxL0mJ6nzjB25e5IPwqV1VOsY7ah6UB1DG+VOXAIMtuC54rFJGiHkxjgA==",
+			"version": "7.8.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.8.6.tgz",
+			"integrity": "sha512-klTBDdsr+VFFqaDHm5rR69OpEQtO2Qv8ECxHS1mNhJJvaHArR6a1xTf5K/eZW7eZpJbhCx3NW1Yt/sKsLXLblg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-function-name": "^7.7.4",
-				"@babel/helper-member-expression-to-functions": "^7.7.4",
-				"@babel/helper-optimise-call-expression": "^7.7.4",
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/helper-replace-supers": "^7.7.4",
-				"@babel/helper-split-export-declaration": "^7.7.4"
+				"@babel/helper-function-name": "^7.8.3",
+				"@babel/helper-member-expression-to-functions": "^7.8.3",
+				"@babel/helper-optimise-call-expression": "^7.8.3",
+				"@babel/helper-plugin-utils": "^7.8.3",
+				"@babel/helper-replace-supers": "^7.8.6",
+				"@babel/helper-split-export-declaration": "^7.8.3"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.8.3",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+					"integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.8.3"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.8.3",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
+					"integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.8.3",
+						"@babel/template": "^7.8.3",
+						"@babel/types": "^7.8.3"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.8.3",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
+					"integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.8.3"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.8.3",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
+					"integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.8.3"
+					}
+				},
+				"@babel/highlight": {
+					"version": "7.8.3",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
+					"integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.0.0",
+						"esutils": "^2.0.2",
+						"js-tokens": "^4.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.8.6",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.6.tgz",
+					"integrity": "sha512-trGNYSfwq5s0SgM1BMEB8hX3NDmO7EP2wsDGDexiaKMB92BaRpS+qZfpkMqUBhcsOTBwNy9B/jieo4ad/t/z2g==",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.8.6",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.6.tgz",
+					"integrity": "sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.8.3",
+						"@babel/parser": "^7.8.6",
+						"@babel/types": "^7.8.6"
+					}
+				},
+				"@babel/types": {
+					"version": "7.8.6",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.6.tgz",
+					"integrity": "sha512-wqz7pgWMIrht3gquyEFPVXeXCti72Rm8ep9b5tQKz9Yg9LzJA3HxosF1SB3Kc81KD1A3XBkkVYtJvCKS2Z/QrA==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
 			}
 		},
 		"@babel/helper-create-regexp-features-plugin": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.7.4.tgz",
-			"integrity": "sha512-Mt+jBKaxL0zfOIWrfQpnfYCN7/rS6GKx6CCCfuoqVVd+17R8zNDlzVYmIi9qyb2wOk002NsmSTDymkIygDUH7A==",
+			"version": "7.8.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.8.6.tgz",
+			"integrity": "sha512-bPyujWfsHhV/ztUkwGHz/RPV1T1TDEsSZDsN42JPehndA+p1KKTh3npvTadux0ZhCrytx9tvjpWNowKby3tM6A==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-regex": "^7.4.4",
+				"@babel/helper-annotate-as-pure": "^7.8.3",
+				"@babel/helper-regex": "^7.8.3",
 				"regexpu-core": "^4.6.0"
 			}
 		},
 		"@babel/helper-define-map": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.7.4.tgz",
-			"integrity": "sha512-v5LorqOa0nVQUvAUTUF3KPastvUt/HzByXNamKQ6RdJRTV7j8rLL+WB5C/MzzWAwOomxDhYFb1wLLxHqox86lg==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.8.3.tgz",
+			"integrity": "sha512-PoeBYtxoZGtct3md6xZOCWPcKuMuk3IHhgxsRRNtnNShebf4C8YonTSblsK4tvDbm+eJAw2HAPOfCr+Q/YRG/g==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-function-name": "^7.7.4",
-				"@babel/types": "^7.7.4",
+				"@babel/helper-function-name": "^7.8.3",
+				"@babel/types": "^7.8.3",
 				"lodash": "^4.17.13"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.8.3",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+					"integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.8.3"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.8.3",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
+					"integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.8.3",
+						"@babel/template": "^7.8.3",
+						"@babel/types": "^7.8.3"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.8.3",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
+					"integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.8.3"
+					}
+				},
+				"@babel/highlight": {
+					"version": "7.8.3",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
+					"integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.0.0",
+						"esutils": "^2.0.2",
+						"js-tokens": "^4.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.8.6",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.6.tgz",
+					"integrity": "sha512-trGNYSfwq5s0SgM1BMEB8hX3NDmO7EP2wsDGDexiaKMB92BaRpS+qZfpkMqUBhcsOTBwNy9B/jieo4ad/t/z2g==",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.8.6",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.6.tgz",
+					"integrity": "sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.8.3",
+						"@babel/parser": "^7.8.6",
+						"@babel/types": "^7.8.6"
+					}
+				},
+				"@babel/types": {
+					"version": "7.8.6",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.6.tgz",
+					"integrity": "sha512-wqz7pgWMIrht3gquyEFPVXeXCti72Rm8ep9b5tQKz9Yg9LzJA3HxosF1SB3Kc81KD1A3XBkkVYtJvCKS2Z/QrA==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
 			}
 		},
 		"@babel/helper-explode-assignable-expression": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.7.4.tgz",
-			"integrity": "sha512-2/SicuFrNSXsZNBxe5UGdLr+HZg+raWBLE9vC98bdYOKX/U6PY0mdGlYUJdtTDPSU0Lw0PNbKKDpwYHJLn2jLg==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.8.3.tgz",
+			"integrity": "sha512-N+8eW86/Kj147bO9G2uclsg5pwfs/fqqY5rwgIL7eTBklgXjcOJ3btzS5iM6AitJcftnY7pm2lGsrJVYLGjzIw==",
 			"dev": true,
 			"requires": {
-				"@babel/traverse": "^7.7.4",
-				"@babel/types": "^7.7.4"
+				"@babel/traverse": "^7.8.3",
+				"@babel/types": "^7.8.3"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.8.3",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+					"integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.8.3"
+					}
+				},
+				"@babel/generator": {
+					"version": "7.8.6",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.6.tgz",
+					"integrity": "sha512-4bpOR5ZBz+wWcMeVtcf7FbjcFzCp+817z2/gHNncIRcM9MmKzUhtWCYAq27RAfUrAFwb+OCG1s9WEaVxfi6cjg==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.8.6",
+						"jsesc": "^2.5.1",
+						"lodash": "^4.17.13",
+						"source-map": "^0.5.0"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.8.3",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
+					"integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.8.3",
+						"@babel/template": "^7.8.3",
+						"@babel/types": "^7.8.3"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.8.3",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
+					"integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.8.3"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.8.3",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
+					"integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.8.3"
+					}
+				},
+				"@babel/highlight": {
+					"version": "7.8.3",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
+					"integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.0.0",
+						"esutils": "^2.0.2",
+						"js-tokens": "^4.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.8.6",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.6.tgz",
+					"integrity": "sha512-trGNYSfwq5s0SgM1BMEB8hX3NDmO7EP2wsDGDexiaKMB92BaRpS+qZfpkMqUBhcsOTBwNy9B/jieo4ad/t/z2g==",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.8.6",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.6.tgz",
+					"integrity": "sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.8.3",
+						"@babel/parser": "^7.8.6",
+						"@babel/types": "^7.8.6"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.8.6",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.6.tgz",
+					"integrity": "sha512-2B8l0db/DPi8iinITKuo7cbPznLCEk0kCxDoB9/N6gGNg/gxOXiR/IcymAFPiBwk5w6TtQ27w4wpElgp9btR9A==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.8.3",
+						"@babel/generator": "^7.8.6",
+						"@babel/helper-function-name": "^7.8.3",
+						"@babel/helper-split-export-declaration": "^7.8.3",
+						"@babel/parser": "^7.8.6",
+						"@babel/types": "^7.8.6",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0",
+						"lodash": "^4.17.13"
+					}
+				},
+				"@babel/types": {
+					"version": "7.8.6",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.6.tgz",
+					"integrity": "sha512-wqz7pgWMIrht3gquyEFPVXeXCti72Rm8ep9b5tQKz9Yg9LzJA3HxosF1SB3Kc81KD1A3XBkkVYtJvCKS2Z/QrA==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"ms": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+					"dev": true
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
 			}
 		},
 		"@babel/helper-function-name": {
@@ -183,103 +893,639 @@
 			}
 		},
 		"@babel/helper-hoist-variables": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.7.4.tgz",
-			"integrity": "sha512-wQC4xyvc1Jo/FnLirL6CEgPgPCa8M74tOdjWpRhQYapz5JC7u3NYU1zCVoVAGCE3EaIP9T1A3iW0WLJ+reZlpQ==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.8.3.tgz",
+			"integrity": "sha512-ky1JLOjcDUtSc+xkt0xhYff7Z6ILTAHKmZLHPxAhOP0Nd77O+3nCsd6uSVYur6nJnCI029CrNbYlc0LoPfAPQg==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.7.4"
+				"@babel/types": "^7.8.3"
+			},
+			"dependencies": {
+				"@babel/types": {
+					"version": "7.8.6",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.6.tgz",
+					"integrity": "sha512-wqz7pgWMIrht3gquyEFPVXeXCti72Rm8ep9b5tQKz9Yg9LzJA3HxosF1SB3Kc81KD1A3XBkkVYtJvCKS2Z/QrA==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				}
 			}
 		},
 		"@babel/helper-member-expression-to-functions": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.7.4.tgz",
-			"integrity": "sha512-9KcA1X2E3OjXl/ykfMMInBK+uVdfIVakVe7W7Lg3wfXUNyS3Q1HWLFRwZIjhqiCGbslummPDnmb7vIekS0C1vw==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.8.3.tgz",
+			"integrity": "sha512-fO4Egq88utkQFjbPrSHGmGLFqmrshs11d46WI+WZDESt7Wu7wN2G2Iu+NMMZJFDOVRHAMIkB5SNh30NtwCA7RA==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.7.4"
+				"@babel/types": "^7.8.3"
+			},
+			"dependencies": {
+				"@babel/types": {
+					"version": "7.8.6",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.6.tgz",
+					"integrity": "sha512-wqz7pgWMIrht3gquyEFPVXeXCti72Rm8ep9b5tQKz9Yg9LzJA3HxosF1SB3Kc81KD1A3XBkkVYtJvCKS2Z/QrA==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				}
 			}
 		},
 		"@babel/helper-module-imports": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.7.4.tgz",
-			"integrity": "sha512-dGcrX6K9l8258WFjyDLJwuVKxR4XZfU0/vTUgOQYWEnRD8mgr+p4d6fCUMq/ys0h4CCt/S5JhbvtyErjWouAUQ==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.8.3.tgz",
+			"integrity": "sha512-R0Bx3jippsbAEtzkpZ/6FIiuzOURPcMjHp+Z6xPe6DtApDJx+w7UYyOLanZqO8+wKR9G10s/FmHXvxaMd9s6Kg==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.7.4"
+				"@babel/types": "^7.8.3"
+			},
+			"dependencies": {
+				"@babel/types": {
+					"version": "7.8.6",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.6.tgz",
+					"integrity": "sha512-wqz7pgWMIrht3gquyEFPVXeXCti72Rm8ep9b5tQKz9Yg9LzJA3HxosF1SB3Kc81KD1A3XBkkVYtJvCKS2Z/QrA==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				}
 			}
 		},
 		"@babel/helper-module-transforms": {
-			"version": "7.7.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.7.5.tgz",
-			"integrity": "sha512-A7pSxyJf1gN5qXVcidwLWydjftUN878VkalhXX5iQDuGyiGK3sOrrKKHF4/A4fwHtnsotv/NipwAeLzY4KQPvw==",
+			"version": "7.8.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.8.6.tgz",
+			"integrity": "sha512-RDnGJSR5EFBJjG3deY0NiL0K9TO8SXxS9n/MPsbPK/s9LbQymuLNtlzvDiNS7IpecuL45cMeLVkA+HfmlrnkRg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-imports": "^7.7.4",
-				"@babel/helper-simple-access": "^7.7.4",
-				"@babel/helper-split-export-declaration": "^7.7.4",
-				"@babel/template": "^7.7.4",
-				"@babel/types": "^7.7.4",
+				"@babel/helper-module-imports": "^7.8.3",
+				"@babel/helper-replace-supers": "^7.8.6",
+				"@babel/helper-simple-access": "^7.8.3",
+				"@babel/helper-split-export-declaration": "^7.8.3",
+				"@babel/template": "^7.8.6",
+				"@babel/types": "^7.8.6",
 				"lodash": "^4.17.13"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.8.3",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+					"integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.8.3"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.8.3",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
+					"integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.8.3"
+					}
+				},
+				"@babel/highlight": {
+					"version": "7.8.3",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
+					"integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.0.0",
+						"esutils": "^2.0.2",
+						"js-tokens": "^4.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.8.6",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.6.tgz",
+					"integrity": "sha512-trGNYSfwq5s0SgM1BMEB8hX3NDmO7EP2wsDGDexiaKMB92BaRpS+qZfpkMqUBhcsOTBwNy9B/jieo4ad/t/z2g==",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.8.6",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.6.tgz",
+					"integrity": "sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.8.3",
+						"@babel/parser": "^7.8.6",
+						"@babel/types": "^7.8.6"
+					}
+				},
+				"@babel/types": {
+					"version": "7.8.6",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.6.tgz",
+					"integrity": "sha512-wqz7pgWMIrht3gquyEFPVXeXCti72Rm8ep9b5tQKz9Yg9LzJA3HxosF1SB3Kc81KD1A3XBkkVYtJvCKS2Z/QrA==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
 			}
 		},
 		"@babel/helper-optimise-call-expression": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.7.4.tgz",
-			"integrity": "sha512-VB7gWZ2fDkSuqW6b1AKXkJWO5NyNI3bFL/kK79/30moK57blr6NbH8xcl2XcKCwOmJosftWunZqfO84IGq3ZZg==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.8.3.tgz",
+			"integrity": "sha512-Kag20n86cbO2AvHca6EJsvqAd82gc6VMGule4HwebwMlwkpXuVqrNRj6CkCV2sKxgi9MyAUnZVnZ6lJ1/vKhHQ==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.7.4"
+				"@babel/types": "^7.8.3"
+			},
+			"dependencies": {
+				"@babel/types": {
+					"version": "7.8.6",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.6.tgz",
+					"integrity": "sha512-wqz7pgWMIrht3gquyEFPVXeXCti72Rm8ep9b5tQKz9Yg9LzJA3HxosF1SB3Kc81KD1A3XBkkVYtJvCKS2Z/QrA==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				}
 			}
 		},
 		"@babel/helper-plugin-utils": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz",
-			"integrity": "sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz",
+			"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==",
 			"dev": true
 		},
 		"@babel/helper-regex": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.5.5.tgz",
-			"integrity": "sha512-CkCYQLkfkiugbRDO8eZn6lRuR8kzZoGXCg3149iTk5se7g6qykSpy3+hELSwquhu+TgHn8nkLiBwHvNX8Hofcw==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.8.3.tgz",
+			"integrity": "sha512-BWt0QtYv/cg/NecOAZMdcn/waj/5P26DR4mVLXfFtDokSR6fyuG0Pj+e2FqtSME+MqED1khnSMulkmGl8qWiUQ==",
 			"dev": true,
 			"requires": {
 				"lodash": "^4.17.13"
 			}
 		},
 		"@babel/helper-remap-async-to-generator": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.7.4.tgz",
-			"integrity": "sha512-Sk4xmtVdM9sA/jCI80f+KS+Md+ZHIpjuqmYPk1M7F/upHou5e4ReYmExAiu6PVe65BhJPZA2CY9x9k4BqE5klw==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.8.3.tgz",
+			"integrity": "sha512-kgwDmw4fCg7AVgS4DukQR/roGp+jP+XluJE5hsRZwxCYGg+Rv9wSGErDWhlI90FODdYfd4xG4AQRiMDjjN0GzA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-annotate-as-pure": "^7.7.4",
-				"@babel/helper-wrap-function": "^7.7.4",
-				"@babel/template": "^7.7.4",
-				"@babel/traverse": "^7.7.4",
-				"@babel/types": "^7.7.4"
+				"@babel/helper-annotate-as-pure": "^7.8.3",
+				"@babel/helper-wrap-function": "^7.8.3",
+				"@babel/template": "^7.8.3",
+				"@babel/traverse": "^7.8.3",
+				"@babel/types": "^7.8.3"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.8.3",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+					"integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.8.3"
+					}
+				},
+				"@babel/generator": {
+					"version": "7.8.6",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.6.tgz",
+					"integrity": "sha512-4bpOR5ZBz+wWcMeVtcf7FbjcFzCp+817z2/gHNncIRcM9MmKzUhtWCYAq27RAfUrAFwb+OCG1s9WEaVxfi6cjg==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.8.6",
+						"jsesc": "^2.5.1",
+						"lodash": "^4.17.13",
+						"source-map": "^0.5.0"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.8.3",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
+					"integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.8.3",
+						"@babel/template": "^7.8.3",
+						"@babel/types": "^7.8.3"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.8.3",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
+					"integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.8.3"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.8.3",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
+					"integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.8.3"
+					}
+				},
+				"@babel/highlight": {
+					"version": "7.8.3",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
+					"integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.0.0",
+						"esutils": "^2.0.2",
+						"js-tokens": "^4.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.8.6",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.6.tgz",
+					"integrity": "sha512-trGNYSfwq5s0SgM1BMEB8hX3NDmO7EP2wsDGDexiaKMB92BaRpS+qZfpkMqUBhcsOTBwNy9B/jieo4ad/t/z2g==",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.8.6",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.6.tgz",
+					"integrity": "sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.8.3",
+						"@babel/parser": "^7.8.6",
+						"@babel/types": "^7.8.6"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.8.6",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.6.tgz",
+					"integrity": "sha512-2B8l0db/DPi8iinITKuo7cbPznLCEk0kCxDoB9/N6gGNg/gxOXiR/IcymAFPiBwk5w6TtQ27w4wpElgp9btR9A==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.8.3",
+						"@babel/generator": "^7.8.6",
+						"@babel/helper-function-name": "^7.8.3",
+						"@babel/helper-split-export-declaration": "^7.8.3",
+						"@babel/parser": "^7.8.6",
+						"@babel/types": "^7.8.6",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0",
+						"lodash": "^4.17.13"
+					}
+				},
+				"@babel/types": {
+					"version": "7.8.6",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.6.tgz",
+					"integrity": "sha512-wqz7pgWMIrht3gquyEFPVXeXCti72Rm8ep9b5tQKz9Yg9LzJA3HxosF1SB3Kc81KD1A3XBkkVYtJvCKS2Z/QrA==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"ms": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+					"dev": true
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
 			}
 		},
 		"@babel/helper-replace-supers": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.7.4.tgz",
-			"integrity": "sha512-pP0tfgg9hsZWo5ZboYGuBn/bbYT/hdLPVSS4NMmiRJdwWhP0IznPwN9AE1JwyGsjSPLC364I0Qh5p+EPkGPNpg==",
+			"version": "7.8.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.8.6.tgz",
+			"integrity": "sha512-PeMArdA4Sv/Wf4zXwBKPqVj7n9UF/xg6slNRtZW84FM7JpE1CbG8B612FyM4cxrf4fMAMGO0kR7voy1ForHHFA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-member-expression-to-functions": "^7.7.4",
-				"@babel/helper-optimise-call-expression": "^7.7.4",
-				"@babel/traverse": "^7.7.4",
-				"@babel/types": "^7.7.4"
+				"@babel/helper-member-expression-to-functions": "^7.8.3",
+				"@babel/helper-optimise-call-expression": "^7.8.3",
+				"@babel/traverse": "^7.8.6",
+				"@babel/types": "^7.8.6"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.8.3",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+					"integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.8.3"
+					}
+				},
+				"@babel/generator": {
+					"version": "7.8.6",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.6.tgz",
+					"integrity": "sha512-4bpOR5ZBz+wWcMeVtcf7FbjcFzCp+817z2/gHNncIRcM9MmKzUhtWCYAq27RAfUrAFwb+OCG1s9WEaVxfi6cjg==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.8.6",
+						"jsesc": "^2.5.1",
+						"lodash": "^4.17.13",
+						"source-map": "^0.5.0"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.8.3",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
+					"integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.8.3",
+						"@babel/template": "^7.8.3",
+						"@babel/types": "^7.8.3"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.8.3",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
+					"integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.8.3"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.8.3",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
+					"integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.8.3"
+					}
+				},
+				"@babel/highlight": {
+					"version": "7.8.3",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
+					"integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.0.0",
+						"esutils": "^2.0.2",
+						"js-tokens": "^4.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.8.6",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.6.tgz",
+					"integrity": "sha512-trGNYSfwq5s0SgM1BMEB8hX3NDmO7EP2wsDGDexiaKMB92BaRpS+qZfpkMqUBhcsOTBwNy9B/jieo4ad/t/z2g==",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.8.6",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.6.tgz",
+					"integrity": "sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.8.3",
+						"@babel/parser": "^7.8.6",
+						"@babel/types": "^7.8.6"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.8.6",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.6.tgz",
+					"integrity": "sha512-2B8l0db/DPi8iinITKuo7cbPznLCEk0kCxDoB9/N6gGNg/gxOXiR/IcymAFPiBwk5w6TtQ27w4wpElgp9btR9A==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.8.3",
+						"@babel/generator": "^7.8.6",
+						"@babel/helper-function-name": "^7.8.3",
+						"@babel/helper-split-export-declaration": "^7.8.3",
+						"@babel/parser": "^7.8.6",
+						"@babel/types": "^7.8.6",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0",
+						"lodash": "^4.17.13"
+					}
+				},
+				"@babel/types": {
+					"version": "7.8.6",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.6.tgz",
+					"integrity": "sha512-wqz7pgWMIrht3gquyEFPVXeXCti72Rm8ep9b5tQKz9Yg9LzJA3HxosF1SB3Kc81KD1A3XBkkVYtJvCKS2Z/QrA==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"ms": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+					"dev": true
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
 			}
 		},
 		"@babel/helper-simple-access": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.7.4.tgz",
-			"integrity": "sha512-zK7THeEXfan7UlWsG2A6CI/L9jVnI5+xxKZOdej39Y0YtDYKx9raHk5F2EtK9K8DHRTihYwg20ADt9S36GR78A==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.8.3.tgz",
+			"integrity": "sha512-VNGUDjx5cCWg4vvCTR8qQ7YJYZ+HBjxOgXEl7ounz+4Sn7+LMD3CFrCTEU6/qXKbA2nKg21CwhhBzO0RpRbdCw==",
 			"dev": true,
 			"requires": {
-				"@babel/template": "^7.7.4",
-				"@babel/types": "^7.7.4"
+				"@babel/template": "^7.8.3",
+				"@babel/types": "^7.8.3"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.8.3",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+					"integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.8.3"
+					}
+				},
+				"@babel/highlight": {
+					"version": "7.8.3",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
+					"integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.0.0",
+						"esutils": "^2.0.2",
+						"js-tokens": "^4.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.8.6",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.6.tgz",
+					"integrity": "sha512-trGNYSfwq5s0SgM1BMEB8hX3NDmO7EP2wsDGDexiaKMB92BaRpS+qZfpkMqUBhcsOTBwNy9B/jieo4ad/t/z2g==",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.8.6",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.6.tgz",
+					"integrity": "sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.8.3",
+						"@babel/parser": "^7.8.6",
+						"@babel/types": "^7.8.6"
+					}
+				},
+				"@babel/types": {
+					"version": "7.8.6",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.6.tgz",
+					"integrity": "sha512-wqz7pgWMIrht3gquyEFPVXeXCti72Rm8ep9b5tQKz9Yg9LzJA3HxosF1SB3Kc81KD1A3XBkkVYtJvCKS2Z/QrA==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
 			}
 		},
 		"@babel/helper-split-export-declaration": {
@@ -292,26 +1538,342 @@
 			}
 		},
 		"@babel/helper-wrap-function": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.7.4.tgz",
-			"integrity": "sha512-VsfzZt6wmsocOaVU0OokwrIytHND55yvyT4BPB9AIIgwr8+x7617hetdJTsuGwygN5RC6mxA9EJztTjuwm2ofg==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.8.3.tgz",
+			"integrity": "sha512-LACJrbUET9cQDzb6kG7EeD7+7doC3JNvUgTEQOx2qaO1fKlzE/Bf05qs9w1oXQMmXlPO65lC3Tq9S6gZpTErEQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-function-name": "^7.7.4",
-				"@babel/template": "^7.7.4",
-				"@babel/traverse": "^7.7.4",
-				"@babel/types": "^7.7.4"
+				"@babel/helper-function-name": "^7.8.3",
+				"@babel/template": "^7.8.3",
+				"@babel/traverse": "^7.8.3",
+				"@babel/types": "^7.8.3"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.8.3",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+					"integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.8.3"
+					}
+				},
+				"@babel/generator": {
+					"version": "7.8.6",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.6.tgz",
+					"integrity": "sha512-4bpOR5ZBz+wWcMeVtcf7FbjcFzCp+817z2/gHNncIRcM9MmKzUhtWCYAq27RAfUrAFwb+OCG1s9WEaVxfi6cjg==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.8.6",
+						"jsesc": "^2.5.1",
+						"lodash": "^4.17.13",
+						"source-map": "^0.5.0"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.8.3",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
+					"integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.8.3",
+						"@babel/template": "^7.8.3",
+						"@babel/types": "^7.8.3"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.8.3",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
+					"integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.8.3"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.8.3",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
+					"integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.8.3"
+					}
+				},
+				"@babel/highlight": {
+					"version": "7.8.3",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
+					"integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.0.0",
+						"esutils": "^2.0.2",
+						"js-tokens": "^4.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.8.6",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.6.tgz",
+					"integrity": "sha512-trGNYSfwq5s0SgM1BMEB8hX3NDmO7EP2wsDGDexiaKMB92BaRpS+qZfpkMqUBhcsOTBwNy9B/jieo4ad/t/z2g==",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.8.6",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.6.tgz",
+					"integrity": "sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.8.3",
+						"@babel/parser": "^7.8.6",
+						"@babel/types": "^7.8.6"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.8.6",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.6.tgz",
+					"integrity": "sha512-2B8l0db/DPi8iinITKuo7cbPznLCEk0kCxDoB9/N6gGNg/gxOXiR/IcymAFPiBwk5w6TtQ27w4wpElgp9btR9A==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.8.3",
+						"@babel/generator": "^7.8.6",
+						"@babel/helper-function-name": "^7.8.3",
+						"@babel/helper-split-export-declaration": "^7.8.3",
+						"@babel/parser": "^7.8.6",
+						"@babel/types": "^7.8.6",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0",
+						"lodash": "^4.17.13"
+					}
+				},
+				"@babel/types": {
+					"version": "7.8.6",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.6.tgz",
+					"integrity": "sha512-wqz7pgWMIrht3gquyEFPVXeXCti72Rm8ep9b5tQKz9Yg9LzJA3HxosF1SB3Kc81KD1A3XBkkVYtJvCKS2Z/QrA==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"ms": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+					"dev": true
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
 			}
 		},
 		"@babel/helpers": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.7.4.tgz",
-			"integrity": "sha512-ak5NGZGJ6LV85Q1Zc9gn2n+ayXOizryhjSUBTdu5ih1tlVCJeuQENzc4ItyCVhINVXvIT/ZQ4mheGIsfBkpskg==",
+			"version": "7.8.4",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.8.4.tgz",
+			"integrity": "sha512-VPbe7wcQ4chu4TDQjimHv/5tj73qz88o12EPkO2ValS2QiQS/1F2SsjyIGNnAD0vF/nZS6Cf9i+vW6HIlnaR8w==",
 			"dev": true,
 			"requires": {
-				"@babel/template": "^7.7.4",
-				"@babel/traverse": "^7.7.4",
-				"@babel/types": "^7.7.4"
+				"@babel/template": "^7.8.3",
+				"@babel/traverse": "^7.8.4",
+				"@babel/types": "^7.8.3"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.8.3",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+					"integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.8.3"
+					}
+				},
+				"@babel/generator": {
+					"version": "7.8.6",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.6.tgz",
+					"integrity": "sha512-4bpOR5ZBz+wWcMeVtcf7FbjcFzCp+817z2/gHNncIRcM9MmKzUhtWCYAq27RAfUrAFwb+OCG1s9WEaVxfi6cjg==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.8.6",
+						"jsesc": "^2.5.1",
+						"lodash": "^4.17.13",
+						"source-map": "^0.5.0"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.8.3",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
+					"integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.8.3",
+						"@babel/template": "^7.8.3",
+						"@babel/types": "^7.8.3"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.8.3",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
+					"integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.8.3"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.8.3",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
+					"integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.8.3"
+					}
+				},
+				"@babel/highlight": {
+					"version": "7.8.3",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
+					"integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.0.0",
+						"esutils": "^2.0.2",
+						"js-tokens": "^4.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.8.6",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.6.tgz",
+					"integrity": "sha512-trGNYSfwq5s0SgM1BMEB8hX3NDmO7EP2wsDGDexiaKMB92BaRpS+qZfpkMqUBhcsOTBwNy9B/jieo4ad/t/z2g==",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.8.6",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.6.tgz",
+					"integrity": "sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.8.3",
+						"@babel/parser": "^7.8.6",
+						"@babel/types": "^7.8.6"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.8.6",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.6.tgz",
+					"integrity": "sha512-2B8l0db/DPi8iinITKuo7cbPznLCEk0kCxDoB9/N6gGNg/gxOXiR/IcymAFPiBwk5w6TtQ27w4wpElgp9btR9A==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.8.3",
+						"@babel/generator": "^7.8.6",
+						"@babel/helper-function-name": "^7.8.3",
+						"@babel/helper-split-export-declaration": "^7.8.3",
+						"@babel/parser": "^7.8.6",
+						"@babel/types": "^7.8.6",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0",
+						"lodash": "^4.17.13"
+					}
+				},
+				"@babel/types": {
+					"version": "7.8.6",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.6.tgz",
+					"integrity": "sha512-wqz7pgWMIrht3gquyEFPVXeXCti72Rm8ep9b5tQKz9Yg9LzJA3HxosF1SB3Kc81KD1A3XBkkVYtJvCKS2Z/QrA==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"ms": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+					"dev": true
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
 			}
 		},
 		"@babel/highlight": {
@@ -363,498 +1925,829 @@
 			"dev": true
 		},
 		"@babel/plugin-proposal-async-generator-functions": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.7.4.tgz",
-			"integrity": "sha512-1ypyZvGRXriY/QP668+s8sFr2mqinhkRDMPSQLNghCQE+GAkFtp+wkHVvg2+Hdki8gwP+NFzJBJ/N1BfzCCDEw==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.8.3.tgz",
+			"integrity": "sha512-NZ9zLv848JsV3hs8ryEh7Uaz/0KsmPLqv0+PdkDJL1cJy0K4kOCFa8zc1E3mp+RHPQcpdfb/6GovEsW4VDrOMw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/helper-remap-async-to-generator": "^7.7.4",
-				"@babel/plugin-syntax-async-generators": "^7.7.4"
+				"@babel/helper-plugin-utils": "^7.8.3",
+				"@babel/helper-remap-async-to-generator": "^7.8.3",
+				"@babel/plugin-syntax-async-generators": "^7.8.0"
 			}
 		},
 		"@babel/plugin-proposal-class-properties": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.7.4.tgz",
-			"integrity": "sha512-EcuXeV4Hv1X3+Q1TsuOmyyxeTRiSqurGJ26+I/FW1WbymmRRapVORm6x1Zl3iDIHyRxEs+VXWp6qnlcfcJSbbw==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.8.3.tgz",
+			"integrity": "sha512-EqFhbo7IosdgPgZggHaNObkmO1kNUe3slaKu54d5OWvy+p9QIKOzK1GAEpAIsZtWVtPXUHSMcT4smvDrCfY4AA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-create-class-features-plugin": "^7.7.4",
-				"@babel/helper-plugin-utils": "^7.0.0"
+				"@babel/helper-create-class-features-plugin": "^7.8.3",
+				"@babel/helper-plugin-utils": "^7.8.3"
 			}
 		},
 		"@babel/plugin-proposal-decorators": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.7.4.tgz",
-			"integrity": "sha512-GftcVDcLCwVdzKmwOBDjATd548+IE+mBo7ttgatqNDR7VG7GqIuZPtRWlMLHbhTXhcnFZiGER8iIYl1n/imtsg==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.8.3.tgz",
+			"integrity": "sha512-e3RvdvS4qPJVTe288DlXjwKflpfy1hr0j5dz5WpIYYeP7vQZg2WfAEIp8k5/Lwis/m5REXEteIz6rrcDtXXG7w==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-create-class-features-plugin": "^7.7.4",
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/plugin-syntax-decorators": "^7.7.4"
+				"@babel/helper-create-class-features-plugin": "^7.8.3",
+				"@babel/helper-plugin-utils": "^7.8.3",
+				"@babel/plugin-syntax-decorators": "^7.8.3"
+			}
+		},
+		"@babel/plugin-proposal-dynamic-import": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.8.3.tgz",
+			"integrity": "sha512-NyaBbyLFXFLT9FP+zk0kYlUlA8XtCUbehs67F0nnEg7KICgMc2mNkIeu9TYhKzyXMkrapZFwAhXLdnt4IYHy1w==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.3",
+				"@babel/plugin-syntax-dynamic-import": "^7.8.0"
 			}
 		},
 		"@babel/plugin-proposal-json-strings": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.7.4.tgz",
-			"integrity": "sha512-wQvt3akcBTfLU/wYoqm/ws7YOAQKu8EVJEvHip/mzkNtjaclQoCCIqKXFP5/eyfnfbQCDV3OLRIK3mIVyXuZlw==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.8.3.tgz",
+			"integrity": "sha512-KGhQNZ3TVCQG/MjRbAUwuH+14y9q0tpxs1nWWs3pbSleRdDro9SAMMDyye8HhY1gqZ7/NqIc8SKhya0wRDgP1Q==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/plugin-syntax-json-strings": "^7.7.4"
+				"@babel/helper-plugin-utils": "^7.8.3",
+				"@babel/plugin-syntax-json-strings": "^7.8.0"
+			}
+		},
+		"@babel/plugin-proposal-nullish-coalescing-operator": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.8.3.tgz",
+			"integrity": "sha512-TS9MlfzXpXKt6YYomudb/KU7nQI6/xnapG6in1uZxoxDghuSMZsPb6D2fyUwNYSAp4l1iR7QtFOjkqcRYcUsfw==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.3",
+				"@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0"
 			}
 		},
 		"@babel/plugin-proposal-object-rest-spread": {
-			"version": "7.7.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.7.7.tgz",
-			"integrity": "sha512-3qp9I8lelgzNedI3hrhkvhaEYree6+WHnyA/q4Dza9z7iEIs1eyhWyJnetk3jJ69RT0AT4G0UhEGwyGFJ7GUuQ==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.8.3.tgz",
+			"integrity": "sha512-8qvuPwU/xxUCt78HocNlv0mXXo0wdh9VT1R04WU8HGOfaOob26pF+9P5/lYjN/q7DHOX1bvX60hnhOvuQUJdbA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/plugin-syntax-object-rest-spread": "^7.7.4"
+				"@babel/helper-plugin-utils": "^7.8.3",
+				"@babel/plugin-syntax-object-rest-spread": "^7.8.0"
 			}
 		},
 		"@babel/plugin-proposal-optional-catch-binding": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.7.4.tgz",
-			"integrity": "sha512-DyM7U2bnsQerCQ+sejcTNZh8KQEUuC3ufzdnVnSiUv/qoGJp2Z3hanKL18KDhsBT5Wj6a7CMT5mdyCNJsEaA9w==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.8.3.tgz",
+			"integrity": "sha512-0gkX7J7E+AtAw9fcwlVQj8peP61qhdg/89D5swOkjYbkboA2CVckn3kiyum1DE0wskGb7KJJxBdyEBApDLLVdw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/plugin-syntax-optional-catch-binding": "^7.7.4"
+				"@babel/helper-plugin-utils": "^7.8.3",
+				"@babel/plugin-syntax-optional-catch-binding": "^7.8.0"
+			}
+		},
+		"@babel/plugin-proposal-optional-chaining": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.8.3.tgz",
+			"integrity": "sha512-QIoIR9abkVn+seDE3OjA08jWcs3eZ9+wJCKSRgo3WdEU2csFYgdScb+8qHB3+WXsGJD55u+5hWCISI7ejXS+kg==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.3",
+				"@babel/plugin-syntax-optional-chaining": "^7.8.0"
 			}
 		},
 		"@babel/plugin-proposal-unicode-property-regex": {
-			"version": "7.7.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.7.7.tgz",
-			"integrity": "sha512-80PbkKyORBUVm1fbTLrHpYdJxMThzM1UqFGh0ALEhO9TYbG86Ah9zQYAB/84axz2vcxefDLdZwWwZNlYARlu9w==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.8.3.tgz",
+			"integrity": "sha512-1/1/rEZv2XGweRwwSkLpY+s60za9OZ1hJs4YDqFHCw0kYWYwL5IFljVY1MYBL+weT1l9pokDO2uhSTLVxzoHkQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-create-regexp-features-plugin": "^7.7.4",
-				"@babel/helper-plugin-utils": "^7.0.0"
+				"@babel/helper-create-regexp-features-plugin": "^7.8.3",
+				"@babel/helper-plugin-utils": "^7.8.3"
 			}
 		},
 		"@babel/plugin-syntax-async-generators": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.7.4.tgz",
-			"integrity": "sha512-Li4+EjSpBgxcsmeEF8IFcfV/+yJGxHXDirDkEoyFjumuwbmfCVHUt0HuowD/iGM7OhIRyXJH9YXxqiH6N815+g==",
+			"version": "7.8.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
+			"integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
+				"@babel/helper-plugin-utils": "^7.8.0"
 			}
 		},
 		"@babel/plugin-syntax-decorators": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.7.4.tgz",
-			"integrity": "sha512-0oNLWNH4k5ZbBVfAwiTU53rKFWIeTh6ZlaWOXWJc4ywxs0tjz5fc3uZ6jKAnZSxN98eXVgg7bJIuzjX+3SXY+A==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.8.3.tgz",
+			"integrity": "sha512-8Hg4dNNT9/LcA1zQlfwuKR8BUc/if7Q7NkTam9sGTcJphLwpf2g4S42uhspQrIrR+dpzE0dtTqBVFoHl8GtnnQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
+				"@babel/helper-plugin-utils": "^7.8.3"
 			}
 		},
 		"@babel/plugin-syntax-dynamic-import": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.7.4.tgz",
-			"integrity": "sha512-jHQW0vbRGvwQNgyVxwDh4yuXu4bH1f5/EICJLAhl1SblLs2CDhrsmCk+v5XLdE9wxtAFRyxx+P//Iw+a5L/tTg==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.8.3.tgz",
+			"integrity": "sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
+				"@babel/helper-plugin-utils": "^7.8.0"
 			}
 		},
 		"@babel/plugin-syntax-json-strings": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.7.4.tgz",
-			"integrity": "sha512-QpGupahTQW1mHRXddMG5srgpHWqRLwJnJZKXTigB9RPFCCGbDGCgBeM/iC82ICXp414WeYx/tD54w7M2qRqTMg==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
+			"integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
+				"@babel/helper-plugin-utils": "^7.8.0"
 			}
 		},
 		"@babel/plugin-syntax-jsx": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.7.4.tgz",
-			"integrity": "sha512-wuy6fiMe9y7HeZBWXYCGt2RGxZOj0BImZ9EyXJVnVGBKO/Br592rbR3rtIQn0eQhAk9vqaKP5n8tVqEFBQMfLg==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.8.3.tgz",
+			"integrity": "sha512-WxdW9xyLgBdefoo0Ynn3MRSkhe5tFVxxKNVdnZSh318WrG2e2jH+E9wd/++JsqcLJZPfz87njQJ8j2Upjm0M0A==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
+				"@babel/helper-plugin-utils": "^7.8.3"
+			}
+		},
+		"@babel/plugin-syntax-nullish-coalescing-operator": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
+			"integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.0"
 			}
 		},
 		"@babel/plugin-syntax-object-rest-spread": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.7.4.tgz",
-			"integrity": "sha512-mObR+r+KZq0XhRVS2BrBKBpr5jqrqzlPvS9C9vuOf5ilSwzloAl7RPWLrgKdWS6IreaVrjHxTjtyqFiOisaCwg==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
+			"integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
+				"@babel/helper-plugin-utils": "^7.8.0"
 			}
 		},
 		"@babel/plugin-syntax-optional-catch-binding": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.7.4.tgz",
-			"integrity": "sha512-4ZSuzWgFxqHRE31Glu+fEr/MirNZOMYmD/0BhBWyLyOOQz/gTAl7QmWm2hX1QxEIXsr2vkdlwxIzTyiYRC4xcQ==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
+			"integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
+				"@babel/helper-plugin-utils": "^7.8.0"
+			}
+		},
+		"@babel/plugin-syntax-optional-chaining": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
+			"integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			}
+		},
+		"@babel/plugin-syntax-top-level-await": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.8.3.tgz",
+			"integrity": "sha512-kwj1j9lL/6Wd0hROD3b/OZZ7MSrZLqqn9RAZ5+cYYsflQ9HZBIKCUkr3+uL1MEJ1NePiUbf98jjiMQSv0NMR9g==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.3"
 			}
 		},
 		"@babel/plugin-transform-arrow-functions": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.7.4.tgz",
-			"integrity": "sha512-zUXy3e8jBNPiffmqkHRNDdZM2r8DWhCB7HhcoyZjiK1TxYEluLHAvQuYnTT+ARqRpabWqy/NHkO6e3MsYB5YfA==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.8.3.tgz",
+			"integrity": "sha512-0MRF+KC8EqH4dbuITCWwPSzsyO3HIWWlm30v8BbbpOrS1B++isGxPnnuq/IZvOX5J2D/p7DQalQm+/2PnlKGxg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
+				"@babel/helper-plugin-utils": "^7.8.3"
 			}
 		},
 		"@babel/plugin-transform-async-to-generator": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.7.4.tgz",
-			"integrity": "sha512-zpUTZphp5nHokuy8yLlyafxCJ0rSlFoSHypTUWgpdwoDXWQcseaect7cJ8Ppk6nunOM6+5rPMkod4OYKPR5MUg==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.8.3.tgz",
+			"integrity": "sha512-imt9tFLD9ogt56Dd5CI/6XgpukMwd/fLGSrix2httihVe7LOGVPhyhMh1BU5kDM7iHD08i8uUtmV2sWaBFlHVQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-imports": "^7.7.4",
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/helper-remap-async-to-generator": "^7.7.4"
+				"@babel/helper-module-imports": "^7.8.3",
+				"@babel/helper-plugin-utils": "^7.8.3",
+				"@babel/helper-remap-async-to-generator": "^7.8.3"
 			}
 		},
 		"@babel/plugin-transform-block-scoped-functions": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.7.4.tgz",
-			"integrity": "sha512-kqtQzwtKcpPclHYjLK//3lH8OFsCDuDJBaFhVwf8kqdnF6MN4l618UDlcA7TfRs3FayrHj+svYnSX8MC9zmUyQ==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.8.3.tgz",
+			"integrity": "sha512-vo4F2OewqjbB1+yaJ7k2EJFHlTP3jR634Z9Cj9itpqNjuLXvhlVxgnjsHsdRgASR8xYDrx6onw4vW5H6We0Jmg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
+				"@babel/helper-plugin-utils": "^7.8.3"
 			}
 		},
 		"@babel/plugin-transform-block-scoping": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.7.4.tgz",
-			"integrity": "sha512-2VBe9u0G+fDt9B5OV5DQH4KBf5DoiNkwFKOz0TCvBWvdAN2rOykCTkrL+jTLxfCAm76l9Qo5OqL7HBOx2dWggg==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.8.3.tgz",
+			"integrity": "sha512-pGnYfm7RNRgYRi7bids5bHluENHqJhrV4bCZRwc5GamaWIIs07N4rZECcmJL6ZClwjDz1GbdMZFtPs27hTB06w==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/helper-plugin-utils": "^7.8.3",
 				"lodash": "^4.17.13"
 			}
 		},
 		"@babel/plugin-transform-classes": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.7.4.tgz",
-			"integrity": "sha512-sK1mjWat7K+buWRuImEzjNf68qrKcrddtpQo3swi9j7dUcG6y6R6+Di039QN2bD1dykeswlagupEmpOatFHHUg==",
+			"version": "7.8.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.8.6.tgz",
+			"integrity": "sha512-k9r8qRay/R6v5aWZkrEclEhKO6mc1CCQr2dLsVHBmOQiMpN6I2bpjX3vgnldUWeEI1GHVNByULVxZ4BdP4Hmdg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-annotate-as-pure": "^7.7.4",
-				"@babel/helper-define-map": "^7.7.4",
-				"@babel/helper-function-name": "^7.7.4",
-				"@babel/helper-optimise-call-expression": "^7.7.4",
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/helper-replace-supers": "^7.7.4",
-				"@babel/helper-split-export-declaration": "^7.7.4",
+				"@babel/helper-annotate-as-pure": "^7.8.3",
+				"@babel/helper-define-map": "^7.8.3",
+				"@babel/helper-function-name": "^7.8.3",
+				"@babel/helper-optimise-call-expression": "^7.8.3",
+				"@babel/helper-plugin-utils": "^7.8.3",
+				"@babel/helper-replace-supers": "^7.8.6",
+				"@babel/helper-split-export-declaration": "^7.8.3",
 				"globals": "^11.1.0"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.8.3",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+					"integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.8.3"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.8.3",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
+					"integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.8.3",
+						"@babel/template": "^7.8.3",
+						"@babel/types": "^7.8.3"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.8.3",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
+					"integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.8.3"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.8.3",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
+					"integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.8.3"
+					}
+				},
+				"@babel/highlight": {
+					"version": "7.8.3",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
+					"integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.0.0",
+						"esutils": "^2.0.2",
+						"js-tokens": "^4.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.8.6",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.6.tgz",
+					"integrity": "sha512-trGNYSfwq5s0SgM1BMEB8hX3NDmO7EP2wsDGDexiaKMB92BaRpS+qZfpkMqUBhcsOTBwNy9B/jieo4ad/t/z2g==",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.8.6",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.6.tgz",
+					"integrity": "sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.8.3",
+						"@babel/parser": "^7.8.6",
+						"@babel/types": "^7.8.6"
+					}
+				},
+				"@babel/types": {
+					"version": "7.8.6",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.6.tgz",
+					"integrity": "sha512-wqz7pgWMIrht3gquyEFPVXeXCti72Rm8ep9b5tQKz9Yg9LzJA3HxosF1SB3Kc81KD1A3XBkkVYtJvCKS2Z/QrA==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
 			}
 		},
 		"@babel/plugin-transform-computed-properties": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.7.4.tgz",
-			"integrity": "sha512-bSNsOsZnlpLLyQew35rl4Fma3yKWqK3ImWMSC/Nc+6nGjC9s5NFWAer1YQ899/6s9HxO2zQC1WoFNfkOqRkqRQ==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.8.3.tgz",
+			"integrity": "sha512-O5hiIpSyOGdrQZRQ2ccwtTVkgUDBBiCuK//4RJ6UfePllUTCENOzKxfh6ulckXKc0DixTFLCfb2HVkNA7aDpzA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
+				"@babel/helper-plugin-utils": "^7.8.3"
 			}
 		},
 		"@babel/plugin-transform-destructuring": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.7.4.tgz",
-			"integrity": "sha512-4jFMXI1Cu2aXbcXXl8Lr6YubCn6Oc7k9lLsu8v61TZh+1jny2BWmdtvY9zSUlLdGUvcy9DMAWyZEOqjsbeg/wA==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.8.3.tgz",
+			"integrity": "sha512-H4X646nCkiEcHZUZaRkhE2XVsoz0J/1x3VVujnn96pSoGCtKPA99ZZA+va+gK+92Zycd6OBKCD8tDb/731bhgQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
+				"@babel/helper-plugin-utils": "^7.8.3"
 			}
 		},
 		"@babel/plugin-transform-dotall-regex": {
-			"version": "7.7.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.7.7.tgz",
-			"integrity": "sha512-b4in+YlTeE/QmTgrllnb3bHA0HntYvjz8O3Mcbx75UBPJA2xhb5A8nle498VhxSXJHQefjtQxpnLPehDJ4TRlg==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.8.3.tgz",
+			"integrity": "sha512-kLs1j9Nn4MQoBYdRXH6AeaXMbEJFaFu/v1nQkvib6QzTj8MZI5OQzqmD83/2jEM1z0DLilra5aWO5YpyC0ALIw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-create-regexp-features-plugin": "^7.7.4",
-				"@babel/helper-plugin-utils": "^7.0.0"
+				"@babel/helper-create-regexp-features-plugin": "^7.8.3",
+				"@babel/helper-plugin-utils": "^7.8.3"
 			}
 		},
 		"@babel/plugin-transform-duplicate-keys": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.7.4.tgz",
-			"integrity": "sha512-g1y4/G6xGWMD85Tlft5XedGaZBCIVN+/P0bs6eabmcPP9egFleMAo65OOjlhcz1njpwagyY3t0nsQC9oTFegJA==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.8.3.tgz",
+			"integrity": "sha512-s8dHiBUbcbSgipS4SMFuWGqCvyge5V2ZeAWzR6INTVC3Ltjig/Vw1G2Gztv0vU/hRG9X8IvKvYdoksnUfgXOEQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
+				"@babel/helper-plugin-utils": "^7.8.3"
 			}
 		},
 		"@babel/plugin-transform-exponentiation-operator": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.7.4.tgz",
-			"integrity": "sha512-MCqiLfCKm6KEA1dglf6Uqq1ElDIZwFuzz1WH5mTf8k2uQSxEJMbOIEh7IZv7uichr7PMfi5YVSrr1vz+ipp7AQ==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.8.3.tgz",
+			"integrity": "sha512-zwIpuIymb3ACcInbksHaNcR12S++0MDLKkiqXHl3AzpgdKlFNhog+z/K0+TGW+b0w5pgTq4H6IwV/WhxbGYSjQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-builder-binary-assignment-operator-visitor": "^7.7.4",
-				"@babel/helper-plugin-utils": "^7.0.0"
+				"@babel/helper-builder-binary-assignment-operator-visitor": "^7.8.3",
+				"@babel/helper-plugin-utils": "^7.8.3"
 			}
 		},
 		"@babel/plugin-transform-for-of": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.7.4.tgz",
-			"integrity": "sha512-zZ1fD1B8keYtEcKF+M1TROfeHTKnijcVQm0yO/Yu1f7qoDoxEIc/+GX6Go430Bg84eM/xwPFp0+h4EbZg7epAA==",
+			"version": "7.8.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.8.6.tgz",
+			"integrity": "sha512-M0pw4/1/KI5WAxPsdcUL/w2LJ7o89YHN3yLkzNjg7Yl15GlVGgzHyCU+FMeAxevHGsLVmUqbirlUIKTafPmzdw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
+				"@babel/helper-plugin-utils": "^7.8.3"
 			}
 		},
 		"@babel/plugin-transform-function-name": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.7.4.tgz",
-			"integrity": "sha512-E/x09TvjHNhsULs2IusN+aJNRV5zKwxu1cpirZyRPw+FyyIKEHPXTsadj48bVpc1R5Qq1B5ZkzumuFLytnbT6g==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.8.3.tgz",
+			"integrity": "sha512-rO/OnDS78Eifbjn5Py9v8y0aR+aSYhDhqAwVfsTl0ERuMZyr05L1aFSCJnbv2mmsLkit/4ReeQ9N2BgLnOcPCQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-function-name": "^7.7.4",
-				"@babel/helper-plugin-utils": "^7.0.0"
+				"@babel/helper-function-name": "^7.8.3",
+				"@babel/helper-plugin-utils": "^7.8.3"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.8.3",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+					"integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.8.3"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.8.3",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
+					"integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.8.3",
+						"@babel/template": "^7.8.3",
+						"@babel/types": "^7.8.3"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.8.3",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
+					"integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.8.3"
+					}
+				},
+				"@babel/highlight": {
+					"version": "7.8.3",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
+					"integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.0.0",
+						"esutils": "^2.0.2",
+						"js-tokens": "^4.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.8.6",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.6.tgz",
+					"integrity": "sha512-trGNYSfwq5s0SgM1BMEB8hX3NDmO7EP2wsDGDexiaKMB92BaRpS+qZfpkMqUBhcsOTBwNy9B/jieo4ad/t/z2g==",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.8.6",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.6.tgz",
+					"integrity": "sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.8.3",
+						"@babel/parser": "^7.8.6",
+						"@babel/types": "^7.8.6"
+					}
+				},
+				"@babel/types": {
+					"version": "7.8.6",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.6.tgz",
+					"integrity": "sha512-wqz7pgWMIrht3gquyEFPVXeXCti72Rm8ep9b5tQKz9Yg9LzJA3HxosF1SB3Kc81KD1A3XBkkVYtJvCKS2Z/QrA==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
 			}
 		},
 		"@babel/plugin-transform-literals": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.7.4.tgz",
-			"integrity": "sha512-X2MSV7LfJFm4aZfxd0yLVFrEXAgPqYoDG53Br/tCKiKYfX0MjVjQeWPIhPHHsCqzwQANq+FLN786fF5rgLS+gw==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.8.3.tgz",
+			"integrity": "sha512-3Tqf8JJ/qB7TeldGl+TT55+uQei9JfYaregDcEAyBZ7akutriFrt6C/wLYIer6OYhleVQvH/ntEhjE/xMmy10A==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
+				"@babel/helper-plugin-utils": "^7.8.3"
+			}
+		},
+		"@babel/plugin-transform-member-expression-literals": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.8.3.tgz",
+			"integrity": "sha512-3Wk2EXhnw+rP+IDkK6BdtPKsUE5IeZ6QOGrPYvw52NwBStw9V1ZVzxgK6fSKSxqUvH9eQPR3tm3cOq79HlsKYA==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.3"
 			}
 		},
 		"@babel/plugin-transform-modules-amd": {
-			"version": "7.7.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.7.5.tgz",
-			"integrity": "sha512-CT57FG4A2ZUNU1v+HdvDSDrjNWBrtCmSH6YbbgN3Lrf0Di/q/lWRxZrE72p3+HCCz9UjfZOEBdphgC0nzOS6DQ==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.8.3.tgz",
+			"integrity": "sha512-MadJiU3rLKclzT5kBH4yxdry96odTUwuqrZM+GllFI/VhxfPz+k9MshJM+MwhfkCdxxclSbSBbUGciBngR+kEQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-transforms": "^7.7.5",
-				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/helper-module-transforms": "^7.8.3",
+				"@babel/helper-plugin-utils": "^7.8.3",
 				"babel-plugin-dynamic-import-node": "^2.3.0"
 			}
 		},
 		"@babel/plugin-transform-modules-commonjs": {
-			"version": "7.7.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.7.5.tgz",
-			"integrity": "sha512-9Cq4zTFExwFhQI6MT1aFxgqhIsMWQWDVwOgLzl7PTWJHsNaqFvklAU+Oz6AQLAS0dJKTwZSOCo20INwktxpi3Q==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.8.3.tgz",
+			"integrity": "sha512-JpdMEfA15HZ/1gNuB9XEDlZM1h/gF/YOH7zaZzQu2xCFRfwc01NXBMHHSTT6hRjlXJJs5x/bfODM3LiCk94Sxg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-transforms": "^7.7.5",
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/helper-simple-access": "^7.7.4",
+				"@babel/helper-module-transforms": "^7.8.3",
+				"@babel/helper-plugin-utils": "^7.8.3",
+				"@babel/helper-simple-access": "^7.8.3",
 				"babel-plugin-dynamic-import-node": "^2.3.0"
 			}
 		},
 		"@babel/plugin-transform-modules-systemjs": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.7.4.tgz",
-			"integrity": "sha512-y2c96hmcsUi6LrMqvmNDPBBiGCiQu0aYqpHatVVu6kD4mFEXKjyNxd/drc18XXAf9dv7UXjrZwBVmTTGaGP8iw==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.8.3.tgz",
+			"integrity": "sha512-8cESMCJjmArMYqa9AO5YuMEkE4ds28tMpZcGZB/jl3n0ZzlsxOAi3mC+SKypTfT8gjMupCnd3YiXCkMjj2jfOg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-hoist-variables": "^7.7.4",
-				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/helper-hoist-variables": "^7.8.3",
+				"@babel/helper-module-transforms": "^7.8.3",
+				"@babel/helper-plugin-utils": "^7.8.3",
 				"babel-plugin-dynamic-import-node": "^2.3.0"
 			}
 		},
 		"@babel/plugin-transform-modules-umd": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.7.4.tgz",
-			"integrity": "sha512-u2B8TIi0qZI4j8q4C51ktfO7E3cQ0qnaXFI1/OXITordD40tt17g/sXqgNNCcMTcBFKrUPcGDx+TBJuZxLx7tw==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.8.3.tgz",
+			"integrity": "sha512-evhTyWhbwbI3/U6dZAnx/ePoV7H6OUG+OjiJFHmhr9FPn0VShjwC2kdxqIuQ/+1P50TMrneGzMeyMTFOjKSnAw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-transforms": "^7.7.4",
-				"@babel/helper-plugin-utils": "^7.0.0"
+				"@babel/helper-module-transforms": "^7.8.3",
+				"@babel/helper-plugin-utils": "^7.8.3"
 			}
 		},
 		"@babel/plugin-transform-named-capturing-groups-regex": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.7.4.tgz",
-			"integrity": "sha512-jBUkiqLKvUWpv9GLSuHUFYdmHg0ujC1JEYoZUfeOOfNydZXp1sXObgyPatpcwjWgsdBGsagWW0cdJpX/DO2jMw==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.8.3.tgz",
+			"integrity": "sha512-f+tF/8UVPU86TrCb06JoPWIdDpTNSGGcAtaD9mLP0aYGA0OS0j7j7DHJR0GTFrUZPUU6loZhbsVZgTh0N+Qdnw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-create-regexp-features-plugin": "^7.7.4"
+				"@babel/helper-create-regexp-features-plugin": "^7.8.3"
 			}
 		},
 		"@babel/plugin-transform-new-target": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.7.4.tgz",
-			"integrity": "sha512-CnPRiNtOG1vRodnsyGX37bHQleHE14B9dnnlgSeEs3ek3fHN1A1SScglTCg1sfbe7sRQ2BUcpgpTpWSfMKz3gg==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.8.3.tgz",
+			"integrity": "sha512-QuSGysibQpyxexRyui2vca+Cmbljo8bcRckgzYV4kRIsHpVeyeC3JDO63pY+xFZ6bWOBn7pfKZTqV4o/ix9sFw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
+				"@babel/helper-plugin-utils": "^7.8.3"
 			}
 		},
 		"@babel/plugin-transform-object-super": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.7.4.tgz",
-			"integrity": "sha512-ho+dAEhC2aRnff2JCA0SAK7V2R62zJd/7dmtoe7MHcso4C2mS+vZjn1Pb1pCVZvJs1mgsvv5+7sT+m3Bysb6eg==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.8.3.tgz",
+			"integrity": "sha512-57FXk+gItG/GejofIyLIgBKTas4+pEU47IXKDBWFTxdPd7F80H8zybyAY7UoblVfBhBGs2EKM+bJUu2+iUYPDQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/helper-replace-supers": "^7.7.4"
+				"@babel/helper-plugin-utils": "^7.8.3",
+				"@babel/helper-replace-supers": "^7.8.3"
 			}
 		},
 		"@babel/plugin-transform-parameters": {
-			"version": "7.7.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.7.7.tgz",
-			"integrity": "sha512-OhGSrf9ZBrr1fw84oFXj5hgi8Nmg+E2w5L7NhnG0lPvpDtqd7dbyilM2/vR8CKbJ907RyxPh2kj6sBCSSfI9Ew==",
+			"version": "7.8.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.8.4.tgz",
+			"integrity": "sha512-IsS3oTxeTsZlE5KqzTbcC2sV0P9pXdec53SU+Yxv7o/6dvGM5AkTotQKhoSffhNgZ/dftsSiOoxy7evCYJXzVA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-call-delegate": "^7.7.4",
-				"@babel/helper-get-function-arity": "^7.7.4",
-				"@babel/helper-plugin-utils": "^7.0.0"
+				"@babel/helper-call-delegate": "^7.8.3",
+				"@babel/helper-get-function-arity": "^7.8.3",
+				"@babel/helper-plugin-utils": "^7.8.3"
+			},
+			"dependencies": {
+				"@babel/helper-get-function-arity": {
+					"version": "7.8.3",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
+					"integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.8.3"
+					}
+				},
+				"@babel/types": {
+					"version": "7.8.6",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.6.tgz",
+					"integrity": "sha512-wqz7pgWMIrht3gquyEFPVXeXCti72Rm8ep9b5tQKz9Yg9LzJA3HxosF1SB3Kc81KD1A3XBkkVYtJvCKS2Z/QrA==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				}
+			}
+		},
+		"@babel/plugin-transform-property-literals": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.8.3.tgz",
+			"integrity": "sha512-uGiiXAZMqEoQhRWMK17VospMZh5sXWg+dlh2soffpkAl96KAm+WZuJfa6lcELotSRmooLqg0MWdH6UUq85nmmg==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.3"
 			}
 		},
 		"@babel/plugin-transform-regenerator": {
-			"version": "7.7.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.7.5.tgz",
-			"integrity": "sha512-/8I8tPvX2FkuEyWbjRCt4qTAgZK0DVy8QRguhA524UH48RfGJy94On2ri+dCuwOpcerPRl9O4ebQkRcVzIaGBw==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.8.3.tgz",
+			"integrity": "sha512-qt/kcur/FxrQrzFR432FGZznkVAjiyFtCOANjkAKwCbt465L6ZCiUQh2oMYGU3Wo8LRFJxNDFwWn106S5wVUNA==",
 			"dev": true,
 			"requires": {
 				"regenerator-transform": "^0.14.0"
 			}
 		},
-		"@babel/plugin-transform-runtime": {
-			"version": "7.7.6",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.7.6.tgz",
-			"integrity": "sha512-tajQY+YmXR7JjTwRvwL4HePqoL3DYxpYXIHKVvrOIvJmeHe2y1w4tz5qz9ObUDC9m76rCzIMPyn4eERuwA4a4A==",
+		"@babel/plugin-transform-reserved-words": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.8.3.tgz",
+			"integrity": "sha512-mwMxcycN3omKFDjDQUl+8zyMsBfjRFr0Zn/64I41pmjv4NJuqcYlEtezwYtw9TFd9WR1vN5kiM+O0gMZzO6L0A==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-imports": "^7.7.4",
-				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/helper-plugin-utils": "^7.8.3"
+			}
+		},
+		"@babel/plugin-transform-runtime": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.8.3.tgz",
+			"integrity": "sha512-/vqUt5Yh+cgPZXXjmaG9NT8aVfThKk7G4OqkVhrXqwsC5soMn/qTCxs36rZ2QFhpfTJcjw4SNDIZ4RUb8OL4jQ==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-module-imports": "^7.8.3",
+				"@babel/helper-plugin-utils": "^7.8.3",
 				"resolve": "^1.8.1",
 				"semver": "^5.5.1"
 			}
 		},
 		"@babel/plugin-transform-shorthand-properties": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.7.4.tgz",
-			"integrity": "sha512-q+suddWRfIcnyG5YiDP58sT65AJDZSUhXQDZE3r04AuqD6d/XLaQPPXSBzP2zGerkgBivqtQm9XKGLuHqBID6Q==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.8.3.tgz",
+			"integrity": "sha512-I9DI6Odg0JJwxCHzbzW08ggMdCezoWcuQRz3ptdudgwaHxTjxw5HgdFJmZIkIMlRymL6YiZcped4TTCB0JcC8w==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
+				"@babel/helper-plugin-utils": "^7.8.3"
 			}
 		},
 		"@babel/plugin-transform-spread": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.7.4.tgz",
-			"integrity": "sha512-8OSs0FLe5/80cndziPlg4R0K6HcWSM0zyNhHhLsmw/Nc5MaA49cAsnoJ/t/YZf8qkG7fD+UjTRaApVDB526d7Q==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.8.3.tgz",
+			"integrity": "sha512-CkuTU9mbmAoFOI1tklFWYYbzX5qCIZVXPVy0jpXgGwkplCndQAa58s2jr66fTeQnA64bDox0HL4U56CFYoyC7g==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
+				"@babel/helper-plugin-utils": "^7.8.3"
 			}
 		},
 		"@babel/plugin-transform-sticky-regex": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.7.4.tgz",
-			"integrity": "sha512-Ls2NASyL6qtVe1H1hXts9yuEeONV2TJZmplLONkMPUG158CtmnrzW5Q5teibM5UVOFjG0D3IC5mzXR6pPpUY7A==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.8.3.tgz",
+			"integrity": "sha512-9Spq0vGCD5Bb4Z/ZXXSK5wbbLFMG085qd2vhL1JYu1WcQ5bXqZBAYRzU1d+p79GcHs2szYv5pVQCX13QgldaWw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/helper-regex": "^7.0.0"
+				"@babel/helper-plugin-utils": "^7.8.3",
+				"@babel/helper-regex": "^7.8.3"
 			}
 		},
 		"@babel/plugin-transform-template-literals": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.7.4.tgz",
-			"integrity": "sha512-sA+KxLwF3QwGj5abMHkHgshp9+rRz+oY9uoRil4CyLtgEuE/88dpkeWgNk5qKVsJE9iSfly3nvHapdRiIS2wnQ==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.8.3.tgz",
+			"integrity": "sha512-820QBtykIQOLFT8NZOcTRJ1UNuztIELe4p9DCgvj4NK+PwluSJ49we7s9FB1HIGNIYT7wFUJ0ar2QpCDj0escQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-annotate-as-pure": "^7.7.4",
-				"@babel/helper-plugin-utils": "^7.0.0"
+				"@babel/helper-annotate-as-pure": "^7.8.3",
+				"@babel/helper-plugin-utils": "^7.8.3"
 			}
 		},
 		"@babel/plugin-transform-typeof-symbol": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.7.4.tgz",
-			"integrity": "sha512-KQPUQ/7mqe2m0B8VecdyaW5XcQYaePyl9R7IsKd+irzj6jvbhoGnRE+M0aNkyAzI07VfUQ9266L5xMARitV3wg==",
+			"version": "7.8.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.8.4.tgz",
+			"integrity": "sha512-2QKyfjGdvuNfHsb7qnBBlKclbD4CfshH2KvDabiijLMGXPHJXGxtDzwIF7bQP+T0ysw8fYTtxPafgfs/c1Lrqg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
+				"@babel/helper-plugin-utils": "^7.8.3"
 			}
 		},
 		"@babel/plugin-transform-unicode-regex": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.7.4.tgz",
-			"integrity": "sha512-N77UUIV+WCvE+5yHw+oks3m18/umd7y392Zv7mYTpFqHtkpcc+QUz+gLJNTWVlWROIWeLqY0f3OjZxV5TcXnRw==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.8.3.tgz",
+			"integrity": "sha512-+ufgJjYdmWfSQ+6NS9VGUR2ns8cjJjYbrbi11mZBTaWm+Fui/ncTLFF28Ei1okavY+xkojGr1eJxNsWYeA5aZw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-create-regexp-features-plugin": "^7.7.4",
-				"@babel/helper-plugin-utils": "^7.0.0"
+				"@babel/helper-create-regexp-features-plugin": "^7.8.3",
+				"@babel/helper-plugin-utils": "^7.8.3"
 			}
 		},
 		"@babel/preset-env": {
-			"version": "7.3.4",
-			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.3.4.tgz",
-			"integrity": "sha512-2mwqfYMK8weA0g0uBKOt4FE3iEodiHy9/CW0b+nWXcbL+pGzLx8ESYc+j9IIxr6LTDHWKgPm71i9smo02bw+gA==",
+			"version": "7.8.6",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.8.6.tgz",
+			"integrity": "sha512-M5u8llV9DIVXBFB/ArIpqJuvXpO+ymxcJ6e8ZAmzeK3sQeBNOD1y+rHvHCGG4TlEmsNpIrdecsHGHT8ZCoOSJg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-imports": "^7.0.0",
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/plugin-proposal-async-generator-functions": "^7.2.0",
-				"@babel/plugin-proposal-json-strings": "^7.2.0",
-				"@babel/plugin-proposal-object-rest-spread": "^7.3.4",
-				"@babel/plugin-proposal-optional-catch-binding": "^7.2.0",
-				"@babel/plugin-proposal-unicode-property-regex": "^7.2.0",
-				"@babel/plugin-syntax-async-generators": "^7.2.0",
-				"@babel/plugin-syntax-json-strings": "^7.2.0",
-				"@babel/plugin-syntax-object-rest-spread": "^7.2.0",
-				"@babel/plugin-syntax-optional-catch-binding": "^7.2.0",
-				"@babel/plugin-transform-arrow-functions": "^7.2.0",
-				"@babel/plugin-transform-async-to-generator": "^7.3.4",
-				"@babel/plugin-transform-block-scoped-functions": "^7.2.0",
-				"@babel/plugin-transform-block-scoping": "^7.3.4",
-				"@babel/plugin-transform-classes": "^7.3.4",
-				"@babel/plugin-transform-computed-properties": "^7.2.0",
-				"@babel/plugin-transform-destructuring": "^7.2.0",
-				"@babel/plugin-transform-dotall-regex": "^7.2.0",
-				"@babel/plugin-transform-duplicate-keys": "^7.2.0",
-				"@babel/plugin-transform-exponentiation-operator": "^7.2.0",
-				"@babel/plugin-transform-for-of": "^7.2.0",
-				"@babel/plugin-transform-function-name": "^7.2.0",
-				"@babel/plugin-transform-literals": "^7.2.0",
-				"@babel/plugin-transform-modules-amd": "^7.2.0",
-				"@babel/plugin-transform-modules-commonjs": "^7.2.0",
-				"@babel/plugin-transform-modules-systemjs": "^7.3.4",
-				"@babel/plugin-transform-modules-umd": "^7.2.0",
-				"@babel/plugin-transform-named-capturing-groups-regex": "^7.3.0",
-				"@babel/plugin-transform-new-target": "^7.0.0",
-				"@babel/plugin-transform-object-super": "^7.2.0",
-				"@babel/plugin-transform-parameters": "^7.2.0",
-				"@babel/plugin-transform-regenerator": "^7.3.4",
-				"@babel/plugin-transform-shorthand-properties": "^7.2.0",
-				"@babel/plugin-transform-spread": "^7.2.0",
-				"@babel/plugin-transform-sticky-regex": "^7.2.0",
-				"@babel/plugin-transform-template-literals": "^7.2.0",
-				"@babel/plugin-transform-typeof-symbol": "^7.2.0",
-				"@babel/plugin-transform-unicode-regex": "^7.2.0",
-				"browserslist": "^4.3.4",
+				"@babel/compat-data": "^7.8.6",
+				"@babel/helper-compilation-targets": "^7.8.6",
+				"@babel/helper-module-imports": "^7.8.3",
+				"@babel/helper-plugin-utils": "^7.8.3",
+				"@babel/plugin-proposal-async-generator-functions": "^7.8.3",
+				"@babel/plugin-proposal-dynamic-import": "^7.8.3",
+				"@babel/plugin-proposal-json-strings": "^7.8.3",
+				"@babel/plugin-proposal-nullish-coalescing-operator": "^7.8.3",
+				"@babel/plugin-proposal-object-rest-spread": "^7.8.3",
+				"@babel/plugin-proposal-optional-catch-binding": "^7.8.3",
+				"@babel/plugin-proposal-optional-chaining": "^7.8.3",
+				"@babel/plugin-proposal-unicode-property-regex": "^7.8.3",
+				"@babel/plugin-syntax-async-generators": "^7.8.0",
+				"@babel/plugin-syntax-dynamic-import": "^7.8.0",
+				"@babel/plugin-syntax-json-strings": "^7.8.0",
+				"@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0",
+				"@babel/plugin-syntax-object-rest-spread": "^7.8.0",
+				"@babel/plugin-syntax-optional-catch-binding": "^7.8.0",
+				"@babel/plugin-syntax-optional-chaining": "^7.8.0",
+				"@babel/plugin-syntax-top-level-await": "^7.8.3",
+				"@babel/plugin-transform-arrow-functions": "^7.8.3",
+				"@babel/plugin-transform-async-to-generator": "^7.8.3",
+				"@babel/plugin-transform-block-scoped-functions": "^7.8.3",
+				"@babel/plugin-transform-block-scoping": "^7.8.3",
+				"@babel/plugin-transform-classes": "^7.8.6",
+				"@babel/plugin-transform-computed-properties": "^7.8.3",
+				"@babel/plugin-transform-destructuring": "^7.8.3",
+				"@babel/plugin-transform-dotall-regex": "^7.8.3",
+				"@babel/plugin-transform-duplicate-keys": "^7.8.3",
+				"@babel/plugin-transform-exponentiation-operator": "^7.8.3",
+				"@babel/plugin-transform-for-of": "^7.8.6",
+				"@babel/plugin-transform-function-name": "^7.8.3",
+				"@babel/plugin-transform-literals": "^7.8.3",
+				"@babel/plugin-transform-member-expression-literals": "^7.8.3",
+				"@babel/plugin-transform-modules-amd": "^7.8.3",
+				"@babel/plugin-transform-modules-commonjs": "^7.8.3",
+				"@babel/plugin-transform-modules-systemjs": "^7.8.3",
+				"@babel/plugin-transform-modules-umd": "^7.8.3",
+				"@babel/plugin-transform-named-capturing-groups-regex": "^7.8.3",
+				"@babel/plugin-transform-new-target": "^7.8.3",
+				"@babel/plugin-transform-object-super": "^7.8.3",
+				"@babel/plugin-transform-parameters": "^7.8.4",
+				"@babel/plugin-transform-property-literals": "^7.8.3",
+				"@babel/plugin-transform-regenerator": "^7.8.3",
+				"@babel/plugin-transform-reserved-words": "^7.8.3",
+				"@babel/plugin-transform-shorthand-properties": "^7.8.3",
+				"@babel/plugin-transform-spread": "^7.8.3",
+				"@babel/plugin-transform-sticky-regex": "^7.8.3",
+				"@babel/plugin-transform-template-literals": "^7.8.3",
+				"@babel/plugin-transform-typeof-symbol": "^7.8.4",
+				"@babel/plugin-transform-unicode-regex": "^7.8.3",
+				"@babel/types": "^7.8.6",
+				"browserslist": "^4.8.5",
+				"core-js-compat": "^3.6.2",
 				"invariant": "^2.2.2",
-				"js-levenshtein": "^1.1.3",
-				"semver": "^5.3.0"
+				"levenary": "^1.1.1",
+				"semver": "^5.5.0"
+			},
+			"dependencies": {
+				"@babel/types": {
+					"version": "7.8.6",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.6.tgz",
+					"integrity": "sha512-wqz7pgWMIrht3gquyEFPVXeXCti72Rm8ep9b5tQKz9Yg9LzJA3HxosF1SB3Kc81KD1A3XBkkVYtJvCKS2Z/QrA==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				}
 			}
 		},
 		"@babel/runtime": {
-			"version": "7.7.7",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.7.tgz",
-			"integrity": "sha512-uCnC2JEVAu8AKB5do1WRIsvrdJ0flYx/A/9f/6chdacnEZ7LmavjdsDXr5ksYBegxtuTPR5Va9/+13QF/kFkCA==",
+			"version": "7.8.4",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.4.tgz",
+			"integrity": "sha512-neAp3zt80trRVBI1x0azq6c57aNBqYZH8KhMm3TaB7wEI5Q4A2SHfBHE8w9gOhI/lrqxtEbXZgQIrHP+wvSGwQ==",
 			"dev": true,
 			"requires": {
-				"regenerator-runtime": "^0.13.2"
-			}
-		},
-		"@babel/runtime-corejs2": {
-			"version": "7.7.7",
-			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.7.7.tgz",
-			"integrity": "sha512-P91T3dFYQL7aj44PxOMIAbo66Ag3NbmXG9fseSYaXxapp3K9XTct5HU9IpTOm2D0AoktKusgqzN5YcSxZXEKBQ==",
-			"dev": true,
-			"requires": {
-				"core-js": "^2.6.5",
 				"regenerator-runtime": "^0.13.2"
 			}
 		},
@@ -915,9 +2808,9 @@
 			}
 		},
 		"@mdi/font": {
-			"version": "4.7.95",
-			"resolved": "https://registry.npmjs.org/@mdi/font/-/font-4.7.95.tgz",
-			"integrity": "sha512-/SWooHIFz2dXkQJk3VhEXSbBplOU1lIkGSELAmw0peFEgR8KPqyM//M3vD8WDZETuEOSRVhVqLevP3okrsM5dw=="
+			"version": "4.9.95",
+			"resolved": "https://registry.npmjs.org/@mdi/font/-/font-4.9.95.tgz",
+			"integrity": "sha512-m2sbAs+SMwRnWpkMriBxEulwuhmqRyh6X+hdOZlqSxYZUM2C2TaDnQ4gcilzdoAgru2XYnWViZ/xPuSDGgRXVw=="
 		},
 		"@mrmlnc/readdir-enhanced": {
 			"version": "2.2.1",
@@ -933,6 +2826,27 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
 			"integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==",
+			"dev": true
+		},
+		"@sindresorhus/is": {
+			"version": "0.14.0",
+			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
+			"integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==",
+			"dev": true
+		},
+		"@szmarczak/http-timer": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
+			"integrity": "sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==",
+			"dev": true,
+			"requires": {
+				"defer-to-connect": "^1.0.1"
+			}
+		},
+		"@types/color-name": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
+			"integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
 			"dev": true
 		},
 		"@types/events": {
@@ -959,9 +2873,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "13.1.2",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-13.1.2.tgz",
-			"integrity": "sha512-B8emQA1qeKerqd1dmIsQYnXi+mmAzTB7flExjmy5X1aVAKFNNNDubkavwR13kR6JnpeLp3aLoJhwn9trWPAyFQ==",
+			"version": "13.7.7",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-13.7.7.tgz",
+			"integrity": "sha512-Uo4chgKbnPNlxQwoFmYIwctkQVkMMmsAoGGU4JKwLuvBefF0pCq4FybNSnfkfRCpC7ZW7kttcC/TrRtAJsvGtg==",
 			"dev": true
 		},
 		"@types/q": {
@@ -991,24 +2905,25 @@
 			}
 		},
 		"@vue/babel-preset-app": {
-			"version": "3.12.1",
-			"resolved": "https://registry.npmjs.org/@vue/babel-preset-app/-/babel-preset-app-3.12.1.tgz",
-			"integrity": "sha512-Zjy5jQaikV1Pz+ri0YgXFS7q4/5wCxB5tRkDOEIt5+4105u0Feb/pvH20nVL6nx9GyXrECFfcm7Yxr/z++OaPQ==",
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/@vue/babel-preset-app/-/babel-preset-app-4.2.3.tgz",
+			"integrity": "sha512-Xlc8d9Ebgu9pNZMUxKZWVP2CctVZzfX3LAxjBDWAAIiVpdXX4IkQQCevDhgiANFzlmE3KXtiSgPGs57Sso2g7Q==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-imports": "^7.0.0",
-				"@babel/plugin-proposal-class-properties": "^7.0.0",
-				"@babel/plugin-proposal-decorators": "^7.1.0",
-				"@babel/plugin-syntax-dynamic-import": "^7.0.0",
-				"@babel/plugin-syntax-jsx": "^7.0.0",
-				"@babel/plugin-transform-runtime": "^7.4.0",
-				"@babel/preset-env": "^7.0.0 < 7.4.0",
-				"@babel/runtime": "^7.0.0",
-				"@babel/runtime-corejs2": "^7.2.0",
-				"@vue/babel-preset-jsx": "^1.0.0",
-				"babel-plugin-dynamic-import-node": "^2.2.0",
-				"babel-plugin-module-resolver": "3.2.0",
-				"core-js": "^2.6.5"
+				"@babel/core": "^7.8.4",
+				"@babel/helper-compilation-targets": "^7.8.4",
+				"@babel/helper-module-imports": "^7.8.3",
+				"@babel/plugin-proposal-class-properties": "^7.8.3",
+				"@babel/plugin-proposal-decorators": "^7.8.3",
+				"@babel/plugin-syntax-dynamic-import": "^7.8.3",
+				"@babel/plugin-syntax-jsx": "^7.8.3",
+				"@babel/plugin-transform-runtime": "^7.8.3",
+				"@babel/preset-env": "^7.8.4",
+				"@babel/runtime": "^7.8.4",
+				"@vue/babel-preset-jsx": "^1.1.2",
+				"babel-plugin-dynamic-import-node": "^2.3.0",
+				"core-js": "^3.6.4",
+				"core-js-compat": "^3.6.4"
 			}
 		},
 		"@vue/babel-preset-jsx": {
@@ -1085,9 +3000,9 @@
 			}
 		},
 		"@vue/component-compiler-utils": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/@vue/component-compiler-utils/-/component-compiler-utils-3.1.0.tgz",
-			"integrity": "sha512-OJ7swvl8LtKtX5aYP8jHhO6fQBIRIGkU6rvWzK+CGJiNOnvg16nzcBkd9qMZzW8trI2AsqAKx263nv7kb5rhZw==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@vue/component-compiler-utils/-/component-compiler-utils-3.1.1.tgz",
+			"integrity": "sha512-+lN3nsfJJDGMNz7fCpcoYIORrXo0K3OTsdr8jCM7FuqdI4+70TY6gxY6viJ2Xi1clqyPg7LpeOWwjF31vSMmUw==",
 			"dev": true,
 			"requires": {
 				"consolidate": "^0.15.1",
@@ -1095,29 +3010,12 @@
 				"lru-cache": "^4.1.2",
 				"merge-source-map": "^1.1.0",
 				"postcss": "^7.0.14",
-				"postcss-selector-parser": "^5.0.0",
+				"postcss-selector-parser": "^6.0.2",
 				"prettier": "^1.18.2",
 				"source-map": "~0.6.1",
 				"vue-template-es2015-compiler": "^1.9.0"
 			},
 			"dependencies": {
-				"cssesc": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/cssesc/-/cssesc-2.0.0.tgz",
-					"integrity": "sha512-MsCAG1z9lPdoO/IUMLSBWBSVxVtJ1395VGIQ+Fc2gNdkQ1hNDnQdw3YhA71WJCBW1vdwA0cAnk/DnW6bqoEUYg==",
-					"dev": true
-				},
-				"postcss-selector-parser": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz",
-					"integrity": "sha512-w+zLE5Jhg6Liz8+rQOWEAwtwkyqpfnmsinXjXg6cY7YIONZZtgvE0v2O0uhQBs0peNomOJwWRKt6JBfTdTd3OQ==",
-					"dev": true,
-					"requires": {
-						"cssesc": "^2.0.0",
-						"indexes-of": "^1.0.1",
-						"uniq": "^1.0.1"
-					}
-				},
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -1127,24 +3025,25 @@
 			}
 		},
 		"@vuepress/core": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@vuepress/core/-/core-1.2.0.tgz",
-			"integrity": "sha512-ZIsUkQIF+h4Yk6q4okoRnRwRhcYePu/kNiL0WWPDGycjai8cFqFjLDP/tJjfTKXmn9A62j2ETjSwaiMxCtDkyw==",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/@vuepress/core/-/core-1.3.1.tgz",
+			"integrity": "sha512-BBtM3imJUPwCTz0Fzl++ZLgf1afcsas4jo/wbVvroIdI0R6GEbXdivnisVGD48tZ10WcwvY94tlL1jWO8xV6bg==",
 			"dev": true,
 			"requires": {
-				"@babel/core": "^7.0.0",
-				"@vue/babel-preset-app": "^3.1.1",
-				"@vuepress/markdown": "^1.2.0",
-				"@vuepress/markdown-loader": "^1.2.0",
-				"@vuepress/plugin-last-updated": "^1.2.0",
-				"@vuepress/plugin-register-components": "^1.2.0",
-				"@vuepress/shared-utils": "^1.2.0",
+				"@babel/core": "^7.8.4",
+				"@vue/babel-preset-app": "^4.1.2",
+				"@vuepress/markdown": "^1.3.1",
+				"@vuepress/markdown-loader": "^1.3.1",
+				"@vuepress/plugin-last-updated": "^1.3.1",
+				"@vuepress/plugin-register-components": "^1.3.1",
+				"@vuepress/shared-utils": "^1.3.1",
 				"autoprefixer": "^9.5.1",
 				"babel-loader": "^8.0.4",
 				"cache-loader": "^3.0.0",
 				"chokidar": "^2.0.3",
 				"connect-history-api-fallback": "^1.5.0",
 				"copy-webpack-plugin": "^5.0.2",
+				"core-js": "^3.6.4",
 				"cross-spawn": "^6.0.5",
 				"css-loader": "^2.1.1",
 				"file-loader": "^3.0.1",
@@ -1165,7 +3064,7 @@
 				"vuepress-html-webpack-plugin": "^3.2.0",
 				"vuepress-plugin-container": "^2.0.2",
 				"webpack": "^4.8.1",
-				"webpack-chain": "^4.6.0",
+				"webpack-chain": "^6.0.0",
 				"webpack-dev-server": "^3.5.1",
 				"webpack-merge": "^4.1.2",
 				"webpackbar": "3.2.0"
@@ -1202,12 +3101,12 @@
 			}
 		},
 		"@vuepress/markdown": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@vuepress/markdown/-/markdown-1.2.0.tgz",
-			"integrity": "sha512-RLRQmTu5wJbCO4Qv+J0K53o5Ew7nAGItLwWyzCbIUB6pRsya3kqSCViWQVlKlS53zFTmRHuAC9tJMRdzly3mCA==",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/@vuepress/markdown/-/markdown-1.3.1.tgz",
+			"integrity": "sha512-UJoGHR9GsFnPk+Jot8tieO4M6WJQ5CkdIWlQfbpC1+Z0ETJjlNIel23BKLNzqfo3NhLq+/i33RnzMVzkBKlVvQ==",
 			"dev": true,
 			"requires": {
-				"@vuepress/shared-utils": "^1.2.0",
+				"@vuepress/shared-utils": "^1.3.1",
 				"markdown-it": "^8.4.1",
 				"markdown-it-anchor": "^5.0.2",
 				"markdown-it-chain": "^1.3.0",
@@ -1217,12 +3116,12 @@
 			}
 		},
 		"@vuepress/markdown-loader": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@vuepress/markdown-loader/-/markdown-loader-1.2.0.tgz",
-			"integrity": "sha512-gOZzoHjfp/W6t+qKBRdbHS/9TwRnNuhY7V+yFzxofNONFHQULofIN/arG+ptYc2SuqJ541jqudNQW+ldHNMC2w==",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/@vuepress/markdown-loader/-/markdown-loader-1.3.1.tgz",
+			"integrity": "sha512-JxjQgSClW51hE0bCrcAqnG0yrvVURzcZwP2zbWkcCMD7vomHbvkHyPmuf6oa8Jk4S//RQUYINrzC/KrDjVuzIQ==",
 			"dev": true,
 			"requires": {
-				"@vuepress/markdown": "^1.2.0",
+				"@vuepress/markdown": "^1.3.1",
 				"loader-utils": "^1.1.0",
 				"lru-cache": "^5.1.1"
 			},
@@ -1245,33 +3144,33 @@
 			}
 		},
 		"@vuepress/plugin-active-header-links": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@vuepress/plugin-active-header-links/-/plugin-active-header-links-1.2.0.tgz",
-			"integrity": "sha512-vdi7l96pElJvEmcx6t9DWJNH25TIurS8acjN3+b7o4NzdaszFn5j6klN6WtI4Z+5BVDrxHP5W1F3Ebw8SZyupA==",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/@vuepress/plugin-active-header-links/-/plugin-active-header-links-1.3.1.tgz",
+			"integrity": "sha512-mrawXXAv2K1GrD1JNoFHxF8xX3KiphVcwvf+58GXpsyAQ5ag5X1BZG3gCA1JdNFUe3SXRh5jF6HTBuM2dc6Ovg==",
 			"dev": true,
 			"requires": {
 				"lodash.debounce": "^4.0.8"
 			}
 		},
 		"@vuepress/plugin-back-to-top": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@vuepress/plugin-back-to-top/-/plugin-back-to-top-1.2.0.tgz",
-			"integrity": "sha512-QGFT5llXnqs/nrUmNql4jZuqo5VTKx/hsK9j1uNRdGBkyiqMs6h+brSpwTKtUqh/XwsCGn7FGPZLaYNkw7Oi8w==",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/@vuepress/plugin-back-to-top/-/plugin-back-to-top-1.3.1.tgz",
+			"integrity": "sha512-vjfYqSnlZy7Z1Hmre7rw3crtUk9nVUJw+fG0CKp5VXLdBnzrACZznxrFw1BhuzqnV9UT3vq6n8MTlcbpq2Xs8g==",
 			"dev": true,
 			"requires": {
 				"lodash.debounce": "^4.0.8"
 			}
 		},
 		"@vuepress/plugin-google-analytics": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@vuepress/plugin-google-analytics/-/plugin-google-analytics-1.2.0.tgz",
-			"integrity": "sha512-0zol5D4Efb5GKel7ADO/s65MLtKSLnOEGkeWzuipkWomSQPzP7TJ3+/RcYBnGdyBFHd1BSpTUHGK0b/IGwM3UA==",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/@vuepress/plugin-google-analytics/-/plugin-google-analytics-1.3.1.tgz",
+			"integrity": "sha512-Xb7g86JT/LD1sLYG2txvpp4ztDTOqN5yNRZK5OtzEekCh0NWxIxz0fEYKqVlaskIFnzoA1dfizudyjGCKY+hMw==",
 			"dev": true
 		},
 		"@vuepress/plugin-last-updated": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@vuepress/plugin-last-updated/-/plugin-last-updated-1.2.0.tgz",
-			"integrity": "sha512-j4uZb/MXDyG+v9QCG3T/rkiaOhC/ib7NKCt1cjn3GOwvWTDmB5UZm9EBhUpbDNrBgxW+SaHOe3kMVNO8bGOTGw==",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/@vuepress/plugin-last-updated/-/plugin-last-updated-1.3.1.tgz",
+			"integrity": "sha512-n1EhhFcaWxQtbC9ICyLg8kmSULjV18wYMbHCyaKRYAvyhlPau95zbSpQfG2Nl3ZgFR6kRodK6AmZUOgho0zh/g==",
 			"dev": true,
 			"requires": {
 				"cross-spawn": "^6.0.5"
@@ -1293,33 +3192,33 @@
 			}
 		},
 		"@vuepress/plugin-nprogress": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@vuepress/plugin-nprogress/-/plugin-nprogress-1.2.0.tgz",
-			"integrity": "sha512-0apt3Dp6XVCOkLViX6seKSEJgARihi+pX3/r8j8ndFp9Y+vmgLFZnQnGE5iKNi1ty+A6PZOK0RQcBjwTAU4pAw==",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/@vuepress/plugin-nprogress/-/plugin-nprogress-1.3.1.tgz",
+			"integrity": "sha512-vDBnIhTgGZbADwhaatSLsFnuj+MDDpCWQ79m9o+8RtMZO2HemedcCRNIj/ZLRJSBFjXrDdnXF5lpW4EEIeRaew==",
 			"dev": true,
 			"requires": {
 				"nprogress": "^0.2.0"
 			}
 		},
 		"@vuepress/plugin-register-components": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@vuepress/plugin-register-components/-/plugin-register-components-1.2.0.tgz",
-			"integrity": "sha512-C32b8sbGtDEX8I3SUUKS/w2rThiRFiKxmzNcJD996me7VY/4rgmZ8CxGtb6G9wByVoK0UdG1SOkrgOPdSCm80A==",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/@vuepress/plugin-register-components/-/plugin-register-components-1.3.1.tgz",
+			"integrity": "sha512-ae/94omRTPZkJKuVic8Rvzfnu2NtqsyVPYTL6qcnjDgxieR3L7EAYLNEvYpg1jof+QTHoEDCaVU2c63chZcfEQ==",
 			"dev": true,
 			"requires": {
-				"@vuepress/shared-utils": "^1.2.0"
+				"@vuepress/shared-utils": "^1.3.1"
 			}
 		},
 		"@vuepress/plugin-search": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@vuepress/plugin-search/-/plugin-search-1.2.0.tgz",
-			"integrity": "sha512-QU3JfnMfImDAArbJOVH1q1iCDE5QrT99GLpNGo6KQYZWqY1TWAbgyf8C2hQdaI03co1lkU2Wn/iqzHJ5WHlueg==",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/@vuepress/plugin-search/-/plugin-search-1.3.1.tgz",
+			"integrity": "sha512-iOIvMWUTPHrGxjDprFoGTcuI8Y8/6e6JjLO4mO6qe6qVqR1yCQ8cJzVYXIizjEHUFYJ04uZ3jF9gBV8npS+3ZQ==",
 			"dev": true
 		},
 		"@vuepress/shared-utils": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@vuepress/shared-utils/-/shared-utils-1.2.0.tgz",
-			"integrity": "sha512-wo5Ng2/xzsmIYCzvWxgLFlDBp7FkmJp2shAkbSurLNAh1vixhs0+LyDxsk01+m34ktJSp9rTUUsm6khw/Fvo0w==",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/@vuepress/shared-utils/-/shared-utils-1.3.1.tgz",
+			"integrity": "sha512-MlIAlnptjDC9+l0SJKW6BpkuwtxfKDzq4Rmag75RdyIqkkNv4EsCXZ8Y3HSuzENWFBwoD31jLC+nCZ3hULcvSg==",
 			"dev": true,
 			"requires": {
 				"chalk": "^2.3.2",
@@ -1371,14 +3270,14 @@
 			}
 		},
 		"@vuepress/theme-default": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@vuepress/theme-default/-/theme-default-1.2.0.tgz",
-			"integrity": "sha512-mJxAMYQQv4OrGFsArMlONu8RpCzPUVx81dumkyTT4ay5PXAWTj+WDeFQLOT3j0g9QrDJGnHhbiw2aS+R/0WUyQ==",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/@vuepress/theme-default/-/theme-default-1.3.1.tgz",
+			"integrity": "sha512-CihkB6/+5vfgeTI5HRDs4+QgTkIN4/K54OpQCGLW51OinXuz4rjMVQW2uSlSqSeKEr+MERHa+Jc5deIpA0opoA==",
 			"dev": true,
 			"requires": {
-				"@vuepress/plugin-active-header-links": "^1.2.0",
-				"@vuepress/plugin-nprogress": "^1.2.0",
-				"@vuepress/plugin-search": "^1.2.0",
+				"@vuepress/plugin-active-header-links": "^1.3.1",
+				"@vuepress/plugin-nprogress": "^1.3.1",
+				"@vuepress/plugin-search": "^1.3.1",
 				"docsearch.js": "^2.5.2",
 				"lodash": "^4.17.15",
 				"stylus": "^0.54.5",
@@ -1691,6 +3590,49 @@
 			"integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
 			"dev": true
 		},
+		"ansi-align": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.0.tgz",
+			"integrity": "sha512-ZpClVKqXN3RGBmKibdfWzqCY4lnjEuoNzU5T0oEFpfd/z5qJHVarukridD4juLO2FXMiwUQxr9WqQtaYa8XRYw==",
+			"dev": true,
+			"requires": {
+				"string-width": "^3.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+					"dev": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+					"dev": true
+				},
+				"string-width": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+					"dev": true,
+					"requires": {
+						"emoji-regex": "^7.0.1",
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^5.1.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^4.1.0"
+					}
+				}
+			}
+		},
 		"ansi-colors": {
 			"version": "3.2.4",
 			"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.4.tgz",
@@ -1956,17 +3898,17 @@
 			}
 		},
 		"autoprefixer": {
-			"version": "9.7.3",
-			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.7.3.tgz",
-			"integrity": "sha512-8T5Y1C5Iyj6PgkPSFd0ODvK9DIleuPKUPYniNxybS47g2k2wFgLZ46lGQHlBuGKIAEV8fbCDfKCCRS1tvOgc3Q==",
+			"version": "9.7.4",
+			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.7.4.tgz",
+			"integrity": "sha512-g0Ya30YrMBAEZk60lp+qfX5YQllG+S5W3GYCFvyHTvhOki0AEQJLPEcIuGRsqVwLi8FvXPVtwTGhfr38hVpm0g==",
 			"dev": true,
 			"requires": {
-				"browserslist": "^4.8.0",
-				"caniuse-lite": "^1.0.30001012",
+				"browserslist": "^4.8.3",
+				"caniuse-lite": "^1.0.30001020",
 				"chalk": "^2.4.2",
 				"normalize-range": "^0.1.2",
 				"num2fraction": "^1.2.2",
-				"postcss": "^7.0.23",
+				"postcss": "^7.0.26",
 				"postcss-value-parser": "^4.0.2"
 			},
 			"dependencies": {
@@ -2008,15 +3950,15 @@
 			"dev": true
 		},
 		"aws4": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.0.tgz",
-			"integrity": "sha512-Uvq6hVe90D0B2WEnUqtdgY1bATGz3mw33nH9Y+dmA+w5DHvUmBgkr5rM/KCHpCsiFNRUfokW/szpPPgMK2hm4A==",
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
+			"integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug==",
 			"dev": true
 		},
 		"axios": {
-			"version": "0.19.1",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-0.19.1.tgz",
-			"integrity": "sha512-Yl+7nfreYKaLRvAvjNPkvfjnQHJM1yLBY3zhqAwcJSwR/6ETkanUgylgtIvkvz0xJ+p/vZuNw8X7Hnb7Whsbpw==",
+			"version": "0.19.2",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
+			"integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
 			"requires": {
 				"follow-redirects": "1.5.10"
 			}
@@ -2062,19 +4004,6 @@
 			"dev": true,
 			"requires": {
 				"object.assign": "^4.1.0"
-			}
-		},
-		"babel-plugin-module-resolver": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-module-resolver/-/babel-plugin-module-resolver-3.2.0.tgz",
-			"integrity": "sha512-tjR0GvSndzPew/Iayf4uICWZqjBwnlMWjSx6brryfQ81F9rxBVqwDJtFCV8oOs0+vJeefK9TmdZtkIFdFe1UnA==",
-			"dev": true,
-			"requires": {
-				"find-babel-config": "^1.1.0",
-				"glob": "^7.1.2",
-				"pkg-up": "^2.0.0",
-				"reselect": "^3.0.1",
-				"resolve": "^1.4.0"
 			}
 		},
 		"balanced-match": {
@@ -2263,6 +4192,118 @@
 			"integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
 			"dev": true
 		},
+		"boxen": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/boxen/-/boxen-4.2.0.tgz",
+			"integrity": "sha512-eB4uT9RGzg2odpER62bBwSLvUeGC+WbRjjyyFhGsKnc8wp/m0+hQsMUvUe3H2V0D5vw0nBdO1hCJoZo5mKeuIQ==",
+			"dev": true,
+			"requires": {
+				"ansi-align": "^3.0.0",
+				"camelcase": "^5.3.1",
+				"chalk": "^3.0.0",
+				"cli-boxes": "^2.2.0",
+				"string-width": "^4.1.0",
+				"term-size": "^2.1.0",
+				"type-fest": "^0.8.1",
+				"widest-line": "^3.1.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+					"dev": true
+				},
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"dev": true,
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"camelcase": {
+					"version": "5.3.1",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+					"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+					"dev": true
+				},
+				"chalk": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"emoji-regex": {
+					"version": "8.0.0",
+					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+					"dev": true
+				},
+				"string-width": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+					"integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+					"dev": true,
+					"requires": {
+						"emoji-regex": "^8.0.0",
+						"is-fullwidth-code-point": "^3.0.0",
+						"strip-ansi": "^6.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^5.0.0"
+					}
+				},
+				"supports-color": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
+			}
+		},
 		"brace-expansion": {
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -2380,14 +4421,14 @@
 			}
 		},
 		"browserslist": {
-			"version": "4.8.2",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.8.2.tgz",
-			"integrity": "sha512-+M4oeaTplPm/f1pXDw84YohEv7B1i/2Aisei8s4s6k3QsoSHa7i5sz8u/cGQkkatCPxMASKxPualR4wwYgVboA==",
+			"version": "4.9.1",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.9.1.tgz",
+			"integrity": "sha512-Q0DnKq20End3raFulq6Vfp1ecB9fh8yUNV55s8sekaDDeqBaCtWlRHCUdaWyUeSSBJM7IbM6HcsyaeYqgeDhnw==",
 			"dev": true,
 			"requires": {
-				"caniuse-lite": "^1.0.30001015",
-				"electron-to-chromium": "^1.3.322",
-				"node-releases": "^1.1.42"
+				"caniuse-lite": "^1.0.30001030",
+				"electron-to-chromium": "^1.3.363",
+				"node-releases": "^1.1.50"
 			}
 		},
 		"buffer": {
@@ -2438,9 +4479,9 @@
 			"dev": true
 		},
 		"cac": {
-			"version": "6.5.3",
-			"resolved": "https://registry.npmjs.org/cac/-/cac-6.5.3.tgz",
-			"integrity": "sha512-wZfzSWVXuue1H3J7TDNjbzg4KTqPXCmh7F3QIzEYXfnhMCcOUrx99M7rpO2UDVJA9dqv3butGj2nHvCV47CmPg==",
+			"version": "6.5.6",
+			"resolved": "https://registry.npmjs.org/cac/-/cac-6.5.6.tgz",
+			"integrity": "sha512-8jsGLeBiYEVYTDExaj/rDPG4tyra4yjjacIL10TQ+MobPcg9/IST+dkKLu6sOzq0GcIC6fQqX1nkH9HoskQLAw==",
 			"dev": true
 		},
 		"cacache": {
@@ -2533,6 +4574,44 @@
 				}
 			}
 		},
+		"cacheable-request": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.1.0.tgz",
+			"integrity": "sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==",
+			"dev": true,
+			"requires": {
+				"clone-response": "^1.0.2",
+				"get-stream": "^5.1.0",
+				"http-cache-semantics": "^4.0.0",
+				"keyv": "^3.0.0",
+				"lowercase-keys": "^2.0.0",
+				"normalize-url": "^4.1.0",
+				"responselike": "^1.0.2"
+			},
+			"dependencies": {
+				"get-stream": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
+					"integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+					"dev": true,
+					"requires": {
+						"pump": "^3.0.0"
+					}
+				},
+				"lowercase-keys": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+					"integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+					"dev": true
+				},
+				"normalize-url": {
+					"version": "4.5.0",
+					"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
+					"integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==",
+					"dev": true
+				}
+			}
+		},
 		"call-me-maybe": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
@@ -2602,9 +4681,9 @@
 			}
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001017",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001017.tgz",
-			"integrity": "sha512-EDnZyOJ6eYh6lHmCvCdHAFbfV4KJ9lSdfv4h/ppEhrU/Yudkl7jujwMZ1we6RX7DXqBfT04pVMQ4J+1wcTlsKA==",
+			"version": "1.0.30001030",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001030.tgz",
+			"integrity": "sha512-QGK0W4Ft/Ac+zTjEiRJfwDNATvS3fodDczBXrH42784kcfqcDKpEPfN08N0HQjrAp8He/Jw8QiSS9QRn7XAbUw==",
 			"dev": true
 		},
 		"caseless": {
@@ -2653,9 +4732,9 @@
 			}
 		},
 		"chownr": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.3.tgz",
-			"integrity": "sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw==",
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+			"integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
 			"dev": true
 		},
 		"chrome-trace-event": {
@@ -2707,9 +4786,9 @@
 			}
 		},
 		"clean-css": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.1.tgz",
-			"integrity": "sha512-4ZxI6dy4lrY6FHzfiy1aEOXgu4LIsW2MhwG0VBKdcoGoH/XLFgaHSdLTGr4O8Be6A8r3MOphEiI8Gc1n0ecf3g==",
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.3.tgz",
+			"integrity": "sha512-VcMWDN54ZN/DS+g58HYL5/n4Zrqe8vHJpGA8KdgUXFU4fuP/aHNw8eld9SyEIyabIMJX/0RaY/fplOo5hYLSFA==",
 			"dev": true,
 			"requires": {
 				"source-map": "~0.6.0"
@@ -2722,6 +4801,12 @@
 					"dev": true
 				}
 			}
+		},
+		"cli-boxes": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.0.tgz",
+			"integrity": "sha512-gpaBrMAizVEANOpfZp/EEUixTXDyGt7DFzdK5hU+UbWt/J0lB0w20ncZj59Z9a93xHb9u12zF5BS6i9RKbtg4w==",
+			"dev": true
 		},
 		"cli-cursor": {
 			"version": "3.1.0",
@@ -2770,6 +4855,15 @@
 				"is-plain-object": "^2.0.4",
 				"kind-of": "^6.0.2",
 				"shallow-clone": "^3.0.0"
+			}
+		},
+		"clone-response": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
+			"integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
+			"dev": true,
+			"requires": {
+				"mimic-response": "^1.0.0"
 			}
 		},
 		"coa": {
@@ -2893,12 +4987,12 @@
 			"dev": true
 		},
 		"compressible": {
-			"version": "2.0.17",
-			"resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.17.tgz",
-			"integrity": "sha512-BGHeLCK1GV7j1bSmQQAi26X+GgWcTjLr/0tzSvMCl3LH1w1IJ4PFSPoV5316b30cneTziC+B1a+3OjoSUcQYmw==",
+			"version": "2.0.18",
+			"resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
+			"integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
 			"dev": true,
 			"requires": {
-				"mime-db": ">= 1.40.0 < 2"
+				"mime-db": ">= 1.43.0 < 2"
 			}
 		},
 		"compression": {
@@ -2943,6 +5037,37 @@
 				"inherits": "^2.0.3",
 				"readable-stream": "^2.2.2",
 				"typedarray": "^0.0.6"
+			}
+		},
+		"configstore": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/configstore/-/configstore-5.0.1.tgz",
+			"integrity": "sha512-aMKprgk5YhBNyH25hj8wGt2+D52Sw1DRRIzqBwLp2Ya9mFmY8KPvvtvmna8SxVR9JMZ4kzMD68N22vlaRpkeFA==",
+			"dev": true,
+			"requires": {
+				"dot-prop": "^5.2.0",
+				"graceful-fs": "^4.1.2",
+				"make-dir": "^3.0.0",
+				"unique-string": "^2.0.0",
+				"write-file-atomic": "^3.0.0",
+				"xdg-basedir": "^4.0.0"
+			},
+			"dependencies": {
+				"make-dir": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.2.tgz",
+					"integrity": "sha512-rYKABKutXa6vXTXhoV18cBE7PaewPXHe/Bdq4v+ZLMhxbWApkFFplT0LcbMW+6BbjnQXzZ/sAvSE/JdguApG5w==",
+					"dev": true,
+					"requires": {
+						"semver": "^6.0.0"
+					}
+				},
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
+				}
 			}
 		},
 		"confusing-browser-globals": {
@@ -3093,9 +5218,9 @@
 					"dev": true
 				},
 				"p-limit": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
-					"integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
+					"version": "2.2.2",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
+					"integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
 					"dev": true,
 					"requires": {
 						"p-try": "^2.0.0"
@@ -3133,10 +5258,28 @@
 			}
 		},
 		"core-js": {
-			"version": "2.6.11",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
-			"integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==",
+			"version": "3.6.4",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.4.tgz",
+			"integrity": "sha512-4paDGScNgZP2IXXilaffL9X7968RuvwlkK3xWtZRVqgd8SYNiVKRJvkFd1aqqEuPfN7E68ZHEp9hDj6lHj4Hyw==",
 			"dev": true
+		},
+		"core-js-compat": {
+			"version": "3.6.4",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.6.4.tgz",
+			"integrity": "sha512-zAa3IZPvsJ0slViBQ2z+vgyyTuhd3MFn1rBQjZSKVEgB0UMYhUkCj9jJUVPgGTGqWvsBVmfnruXgTcNyTlEiSA==",
+			"dev": true,
+			"requires": {
+				"browserslist": "^4.8.3",
+				"semver": "7.0.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
+					"integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==",
+					"dev": true
+				}
+			}
 		},
 		"core-util-is": {
 			"version": "1.0.2",
@@ -3233,6 +5376,12 @@
 				"randombytes": "^2.0.0",
 				"randomfill": "^1.0.3"
 			}
+		},
+		"crypto-random-string": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
+			"integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
+			"dev": true
 		},
 		"css": {
 			"version": "2.2.4",
@@ -3358,12 +5507,6 @@
 					"dev": true
 				}
 			}
-		},
-		"css-unit-converter": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/css-unit-converter/-/css-unit-converter-1.1.1.tgz",
-			"integrity": "sha1-2bkoGtz9jO2TW9urqDeGiX9k6ZY=",
-			"dev": true
 		},
 		"css-what": {
 			"version": "3.2.1",
@@ -3513,6 +5656,15 @@
 			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
 			"dev": true
 		},
+		"decompress-response": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
+			"integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+			"dev": true,
+			"requires": {
+				"mimic-response": "^1.0.0"
+			}
+		},
 		"deep-equal": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
@@ -3526,6 +5678,12 @@
 				"object-keys": "^1.1.1",
 				"regexp.prototype.flags": "^1.2.0"
 			}
+		},
+		"deep-extend": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+			"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+			"dev": true
 		},
 		"deep-is": {
 			"version": "0.1.3",
@@ -3548,6 +5706,12 @@
 				"execa": "^1.0.0",
 				"ip-regex": "^2.1.0"
 			}
+		},
+		"defer-to-connect": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
+			"integrity": "sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ==",
+			"dev": true
 		},
 		"define-properties": {
 			"version": "1.1.3",
@@ -3853,13 +6017,19 @@
 			}
 		},
 		"dot-prop": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
-			"integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.2.0.tgz",
+			"integrity": "sha512-uEUyaDKoSQ1M4Oq8l45hSE26SnTxL6snNnqvK/VWx5wJhmff5z0FUVJDKDanor/6w3kzE3i7XZOk+7wC0EXr1A==",
 			"dev": true,
 			"requires": {
-				"is-obj": "^1.0.0"
+				"is-obj": "^2.0.0"
 			}
+		},
+		"duplexer3": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
+			"integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
+			"dev": true
 		},
 		"duplexify": {
 			"version": "3.7.1",
@@ -3890,9 +6060,9 @@
 			"dev": true
 		},
 		"electron-to-chromium": {
-			"version": "1.3.322",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.322.tgz",
-			"integrity": "sha512-Tc8JQEfGQ1MzfSzI/bTlSr7btJv/FFO7Yh6tanqVmIWOuNCu6/D1MilIEgLtmWqIrsv+o4IjpLAhgMBr/ncNAA==",
+			"version": "1.3.364",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.364.tgz",
+			"integrity": "sha512-V6hyxQ9jzt6Jy6w8tAv4HHKhIaVS6psG/gmwtQ+2+itdkWMHJLHJ4m1sFep/fWkdKvfJcPXuywfnECRzfNa7gw==",
 			"dev": true
 		},
 		"elliptic": {
@@ -3917,9 +6087,9 @@
 			"dev": true
 		},
 		"emojis-list": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
-			"integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
+			"integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
 			"dev": true
 		},
 		"encodeurl": {
@@ -4034,6 +6204,12 @@
 			"version": "4.2.8",
 			"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
 			"integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+			"dev": true
+		},
+		"escape-goat": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/escape-goat/-/escape-goat-2.1.1.tgz",
+			"integrity": "sha512-8/uIhbG12Csjy2JEW7D9pHbreaVaS/OpN3ycnyvElTdwM5n6GY6W6e2IPemfvGZeUMqZ9A/3GqIZMgKnBhAw/Q==",
 			"dev": true
 		},
 		"escape-html": {
@@ -4248,20 +6424,12 @@
 			}
 		},
 		"eslint-config-prettier": {
-			"version": "6.9.0",
-			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.9.0.tgz",
-			"integrity": "sha512-k4E14HBtcLv0uqThaI6I/n1LEqROp8XaPu6SO9Z32u5NlGRC07Enu1Bh2KEFw4FNHbekH8yzbIU9kUGxbiGmCA==",
+			"version": "6.10.0",
+			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.10.0.tgz",
+			"integrity": "sha512-AtndijGte1rPILInUdHjvKEGbIV06NuvPrqlIEaEaWtbtvJh464mDeyGMdZEQMsGvC0ZVkiex1fSNcC4HAbRGg==",
 			"dev": true,
 			"requires": {
 				"get-stdin": "^6.0.0"
-			},
-			"dependencies": {
-				"get-stdin": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
-					"integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
-					"dev": true
-				}
 			}
 		},
 		"eslint-config-standard": {
@@ -4615,9 +6783,9 @@
 			"dev": true
 		},
 		"events": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/events/-/events-3.0.0.tgz",
-			"integrity": "sha512-Dc381HFWJzEOhQ+d8pkNon++bk9h6cdAoAj4iE6Q4y6xgTzySWXlKn05/TVNpjnfRqi/X0EpJEJohPjNI3zpVA==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/events/-/events-3.1.0.tgz",
+			"integrity": "sha512-Rv+u8MLHNOdMjTAFeT3nCjHn2aGlx435FP/sDHNaRhDEMwyI/aB22Kj2qIN8R0cw3z28psEQLYwxVKLsKrMgWg==",
 			"dev": true
 		},
 		"eventsource": {
@@ -5030,30 +7198,6 @@
 					"requires": {
 						"ms": "2.0.0"
 					}
-				}
-			}
-		},
-		"find-babel-config": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/find-babel-config/-/find-babel-config-1.2.0.tgz",
-			"integrity": "sha512-jB2CHJeqy6a820ssiqwrKMeyC6nNdmrcgkKWJWmpoxpE8RKciYJXCcXRq1h2AzCo5I5BJeN2tkGEO3hLTuePRA==",
-			"dev": true,
-			"requires": {
-				"json5": "^0.5.1",
-				"path-exists": "^3.0.0"
-			},
-			"dependencies": {
-				"json5": {
-					"version": "0.5.1",
-					"resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-					"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
-					"dev": true
-				},
-				"path-exists": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-					"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-					"dev": true
 				}
 			}
 		},
@@ -5820,6 +7964,12 @@
 				"globule": "^1.0.0"
 			}
 		},
+		"gensync": {
+			"version": "1.0.0-beta.1",
+			"resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.1.tgz",
+			"integrity": "sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg==",
+			"dev": true
+		},
 		"get-caller-file": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
@@ -5827,9 +7977,9 @@
 			"dev": true
 		},
 		"get-stdin": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-			"integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
+			"integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
 			"dev": true
 		},
 		"get-stream": {
@@ -5907,6 +8057,15 @@
 				"process": "^0.11.10"
 			}
 		},
+		"global-dirs": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-2.0.1.tgz",
+			"integrity": "sha512-5HqUqdhkEovj2Of/ms3IeS/EekcO54ytHRLV4PEY2rhRwrHXLQjeVEES0Lhka0xwNDtGYn58wyC4s5+MHsOO6A==",
+			"dev": true,
+			"requires": {
+				"ini": "^1.3.5"
+			}
+		},
 		"globals": {
 			"version": "11.12.0",
 			"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
@@ -5938,13 +8097,13 @@
 			}
 		},
 		"globule": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/globule/-/globule-1.3.0.tgz",
-			"integrity": "sha512-YlD4kdMqRCQHrhVdonet4TdRtv1/sZKepvoxNT4Nrhrp5HI8XFfc8kFlGlBn2myBo80aGp8Eft259mbcUJhgSg==",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/globule/-/globule-1.3.1.tgz",
+			"integrity": "sha512-OVyWOHgw29yosRHCHo7NncwR1hW5ew0W/UrvtwvjefVJeQ26q4/8r8FmPsSF1hJ93IgWkyv16pCTz6WblMzm/g==",
 			"dev": true,
 			"requires": {
 				"glob": "~7.1.1",
-				"lodash": "~4.17.10",
+				"lodash": "~4.17.12",
 				"minimatch": "~3.0.2"
 			}
 		},
@@ -5956,6 +8115,25 @@
 			"optional": true,
 			"requires": {
 				"delegate": "^3.1.2"
+			}
+		},
+		"got": {
+			"version": "9.6.0",
+			"resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
+			"integrity": "sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==",
+			"dev": true,
+			"requires": {
+				"@sindresorhus/is": "^0.14.0",
+				"@szmarczak/http-timer": "^1.1.2",
+				"cacheable-request": "^6.0.0",
+				"decompress-response": "^3.3.0",
+				"duplexer3": "^0.1.4",
+				"get-stream": "^4.1.0",
+				"lowercase-keys": "^1.0.1",
+				"mimic-response": "^1.0.1",
+				"p-cancelable": "^1.0.0",
+				"to-readable-stream": "^1.0.0",
+				"url-parse-lax": "^3.0.0"
 			}
 		},
 		"graceful-fs": {
@@ -6055,12 +8233,6 @@
 				"kind-of": "^4.0.0"
 			},
 			"dependencies": {
-				"is-buffer": {
-					"version": "1.1.6",
-					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-					"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-					"dev": true
-				},
 				"kind-of": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
@@ -6071,6 +8243,12 @@
 					}
 				}
 			}
+		},
+		"has-yarn": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/has-yarn/-/has-yarn-2.1.0.tgz",
+			"integrity": "sha512-UqBRqi4ju7T+TqGNdqAO0PaSVGsDGJUBQvk9eUWNGRY1CFGDzYhLWoM7JQEemnlvVcv/YEmc2wNW8BC24EnUsw==",
+			"dev": true
 		},
 		"hash-base": {
 			"version": "3.0.4",
@@ -6226,9 +8404,9 @@
 			},
 			"dependencies": {
 				"readable-stream": {
-					"version": "3.4.0",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
-					"integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
 					"dev": true,
 					"requires": {
 						"inherits": "^2.0.3",
@@ -6237,6 +8415,12 @@
 					}
 				}
 			}
+		},
+		"http-cache-semantics": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
+			"integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
+			"dev": true
 		},
 		"http-deceiver": {
 			"version": "1.2.7",
@@ -6387,6 +8571,12 @@
 				"resolve-from": "^3.0.0"
 			}
 		},
+		"import-lazy": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
+			"integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
+			"dev": true
+		},
 		"import-local": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/import-local/-/import-local-2.0.0.tgz",
@@ -6444,6 +8634,12 @@
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
 			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+			"dev": true
+		},
+		"ini": {
+			"version": "1.3.5",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
 			"dev": true
 		},
 		"inquirer": {
@@ -6593,9 +8789,9 @@
 			"dev": true
 		},
 		"ipaddr.js": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.0.tgz",
-			"integrity": "sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA==",
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+			"integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
 			"dev": true
 		},
 		"is-absolute-url": {
@@ -6613,12 +8809,6 @@
 				"kind-of": "^3.0.2"
 			},
 			"dependencies": {
-				"is-buffer": {
-					"version": "1.1.6",
-					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-					"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-					"dev": true
-				},
 				"kind-of": {
 					"version": "3.2.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
@@ -6651,11 +8841,34 @@
 				"binary-extensions": "^1.0.0"
 			}
 		},
+		"is-buffer": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+			"dev": true
+		},
 		"is-callable": {
 			"version": "1.1.5",
 			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
 			"integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
 			"dev": true
+		},
+		"is-ci": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
+			"integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
+			"dev": true,
+			"requires": {
+				"ci-info": "^2.0.0"
+			},
+			"dependencies": {
+				"ci-info": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+					"integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+					"dev": true
+				}
+			}
 		},
 		"is-color-stop": {
 			"version": "1.1.0",
@@ -6680,12 +8893,6 @@
 				"kind-of": "^3.0.2"
 			},
 			"dependencies": {
-				"is-buffer": {
-					"version": "1.1.6",
-					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-					"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-					"dev": true
-				},
 				"kind-of": {
 					"version": "3.2.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
@@ -6741,13 +8948,10 @@
 			"dev": true
 		},
 		"is-finite": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-			"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-			"dev": true,
-			"requires": {
-				"number-is-nan": "^1.0.0"
-			}
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.1.0.tgz",
+			"integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w==",
+			"dev": true
 		},
 		"is-fullwidth-code-point": {
 			"version": "1.0.0",
@@ -6767,6 +8971,30 @@
 				"is-extglob": "^2.1.1"
 			}
 		},
+		"is-installed-globally": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.3.1.tgz",
+			"integrity": "sha512-oiEcGoQbGc+3/iijAijrK2qFpkNoNjsHOm/5V5iaeydyrS/hnwaRCEgH5cpW0P3T1lSjV5piB7S5b5lEugNLhg==",
+			"dev": true,
+			"requires": {
+				"global-dirs": "^2.0.1",
+				"is-path-inside": "^3.0.1"
+			},
+			"dependencies": {
+				"is-path-inside": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.2.tgz",
+					"integrity": "sha512-/2UGPSgmtqwo1ktx8NDHjuPwZWmHhO+gj0f93EkhLB5RgW9RZevWYYlIkS6zePc6U2WpOdQYIwHe9YC4DWEBVg==",
+					"dev": true
+				}
+			}
+		},
+		"is-npm": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/is-npm/-/is-npm-4.0.0.tgz",
+			"integrity": "sha512-96ECIfh9xtDDlPylNPXhzjsykHsMJZ18ASpaWzQyBr4YRTcVjUvzaHayDAES2oU/3KpljhHUjtSRNiDwi0F0ig==",
+			"dev": true
+		},
 		"is-number": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
@@ -6776,12 +9004,6 @@
 				"kind-of": "^3.0.2"
 			},
 			"dependencies": {
-				"is-buffer": {
-					"version": "1.1.6",
-					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-					"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-					"dev": true
-				},
 				"kind-of": {
 					"version": "3.2.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
@@ -6794,9 +9016,9 @@
 			}
 		},
 		"is-obj": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-			"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+			"integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
 			"dev": true
 		},
 		"is-path-cwd": {
@@ -6913,6 +9135,12 @@
 			"integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
 			"dev": true
 		},
+		"is-yarn-global": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/is-yarn-global/-/is-yarn-global-0.3.0.tgz",
+			"integrity": "sha512-VjSeb/lHmkoyd8ryPVIKvOCn4D1koMqY+vqyjjUfc3xyKtP4dYOxM44sZrnqQSzSds3xyOrUTLTC9LVCVgLngw==",
+			"dev": true
+		},
 		"isarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -6949,15 +9177,9 @@
 			"dev": true
 		},
 		"js-base64": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.5.1.tgz",
-			"integrity": "sha512-M7kLczedRMYX4L8Mdh4MzyAMM9O5osx+4FcOQuTvr3A9F2D9S5JXheN0ewNbrvK2UatkTRhL5ejGmGSjNMiZuw==",
-			"dev": true
-		},
-		"js-levenshtein": {
-			"version": "1.1.6",
-			"resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
-			"integrity": "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==",
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.5.2.tgz",
+			"integrity": "sha512-Vg8czh0Q7sFBSUMWWArX/miJeBWYBPpdU/3M/DKSaekLMqrqVPaedp+5mZhie/r0lgrcaYBfwXatEew6gwgiQQ==",
 			"dev": true
 		},
 		"js-tokens": {
@@ -6986,6 +9208,12 @@
 			"version": "2.5.2",
 			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
 			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+			"dev": true
+		},
+		"json-buffer": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
+			"integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=",
 			"dev": true
 		},
 		"json-parse-better-errors": {
@@ -7054,6 +9282,15 @@
 				"verror": "1.10.0"
 			}
 		},
+		"keyv": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
+			"integrity": "sha512-9ykJ/46SN/9KPM/sichzQ7OvXyGDYKGTaDlKMGCAlg2UK8KRy4jb0d8sFc+0Tt0YYnThq8X2RZgCg74RPxgcVA==",
+			"dev": true,
+			"requires": {
+				"json-buffer": "3.0.0"
+			}
+		},
 		"killable": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/killable/-/killable-1.0.1.tgz",
@@ -7061,9 +9298,9 @@
 			"dev": true
 		},
 		"kind-of": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-			"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+			"integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
 			"dev": true
 		},
 		"last-call-webpack-plugin": {
@@ -7076,6 +9313,15 @@
 				"webpack-sources": "^1.1.0"
 			}
 		},
+		"latest-version": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/latest-version/-/latest-version-5.1.0.tgz",
+			"integrity": "sha512-weT+r0kTkRQdCdYCNtkMwWXQTMEswKrFBkm4ckQOMVhhqhIMI1UT2hMj+1iigIhgSZm5gTmrRXBNoGUgaTY1xA==",
+			"dev": true,
+			"requires": {
+				"package-json": "^6.3.0"
+			}
+		},
 		"lcid": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
@@ -7083,6 +9329,21 @@
 			"dev": true,
 			"requires": {
 				"invert-kv": "^1.0.0"
+			}
+		},
+		"leven": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+			"integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+			"dev": true
+		},
+		"levenary": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/levenary/-/levenary-1.1.1.tgz",
+			"integrity": "sha512-mkAdOIt79FD6irqjYSs4rdbnlT5vRonMEvBVPVb3XmevfS8kgRXwfes0dhPdEtzTWD/1eNE/Bm/G1iRt6DcnQQ==",
+			"dev": true,
+			"requires": {
+				"leven": "^3.1.0"
 			}
 		},
 		"levn": {
@@ -7130,13 +9391,13 @@
 			"dev": true
 		},
 		"loader-utils": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.3.tgz",
-			"integrity": "sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
+			"integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
 			"dev": true,
 			"requires": {
 				"big.js": "^5.2.2",
-				"emojis-list": "^2.0.0",
+				"emojis-list": "^3.0.0",
 				"json5": "^1.0.1"
 			}
 		},
@@ -7230,9 +9491,9 @@
 			"dev": true
 		},
 		"loglevel": {
-			"version": "1.6.6",
-			"resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.6.tgz",
-			"integrity": "sha512-Sgr5lbboAUBo3eXCSPL4/KoVz3ROKquOjcctxmHIt+vol2DrqTQe3SwkKKuYhEiWB5kYa13YyopJ69deJ1irzQ==",
+			"version": "1.6.7",
+			"resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.7.tgz",
+			"integrity": "sha512-cY2eLFrQSAfVPhCgH1s7JI73tMbg9YC3v3+ZHVW67sBS7UxWzNEk/ZBbSfLykBWHp33dqqtOv82gjhKEi81T/A==",
 			"dev": true
 		},
 		"loose-envify": {
@@ -7258,6 +9519,12 @@
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
 			"integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw=",
+			"dev": true
+		},
+		"lowercase-keys": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+			"integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
 			"dev": true
 		},
 		"lru-cache": {
@@ -7350,6 +9617,18 @@
 			"dev": true,
 			"requires": {
 				"webpack-chain": "^4.9.0"
+			},
+			"dependencies": {
+				"webpack-chain": {
+					"version": "4.12.1",
+					"resolved": "https://registry.npmjs.org/webpack-chain/-/webpack-chain-4.12.1.tgz",
+					"integrity": "sha512-BCfKo2YkDe2ByqkEWe1Rw+zko4LsyS75LVr29C6xIrxAg9JHJ4pl8kaIZ396SUSNp6b4815dRZPSTAS8LlURRQ==",
+					"dev": true,
+					"requires": {
+						"deepmerge": "^1.5.2",
+						"javascript-stringify": "^1.6.0"
+					}
+				}
 			}
 		},
 		"markdown-it-container": {
@@ -7516,24 +9795,30 @@
 			"dev": true
 		},
 		"mime-db": {
-			"version": "1.42.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.42.0.tgz",
-			"integrity": "sha512-UbfJCR4UAVRNgMpfImz05smAXK7+c+ZntjaA26ANtkXLlOe947Aag5zdIcKQULAiF9Cq4WxBi9jUs5zkA84bYQ==",
+			"version": "1.43.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
+			"integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ==",
 			"dev": true
 		},
 		"mime-types": {
-			"version": "2.1.25",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.25.tgz",
-			"integrity": "sha512-5KhStqB5xpTAeGqKBAMgwaYMnQik7teQN4IAzC7npDv6kzeU6prfkR67bc87J1kWMPGkoaZSq1npmexMgkmEVg==",
+			"version": "2.1.26",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
+			"integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
 			"dev": true,
 			"requires": {
-				"mime-db": "1.42.0"
+				"mime-db": "1.43.0"
 			}
 		},
 		"mimic-fn": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
 			"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+			"dev": true
+		},
+		"mimic-response": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+			"integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
 			"dev": true
 		},
 		"min-document": {
@@ -7826,9 +10111,9 @@
 			}
 		},
 		"node-releases": {
-			"version": "1.1.44",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.44.tgz",
-			"integrity": "sha512-NwbdvJyR7nrcGrXvKAvzc5raj/NkoJudkarh2yIpJ4t0NH4aqjUDz/486P+ynIW5eokKOfzGNRdYoLfBlomruw==",
+			"version": "1.1.50",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.50.tgz",
+			"integrity": "sha512-lgAmPv9eYZ0bGwUYAKlr8MG6K4CvWliWqnkcT2P8mMAgVrH3lqfBPorFlxiG1pHQnqmavJZ9vbMXUTNyMLbrgQ==",
 			"dev": true,
 			"requires": {
 				"semver": "^6.3.0"
@@ -7843,9 +10128,9 @@
 			}
 		},
 		"node-sass": {
-			"version": "4.13.0",
-			"resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.13.0.tgz",
-			"integrity": "sha512-W1XBrvoJ1dy7VsvTAS5q1V45lREbTlZQqFbiHb3R3OTTCma0XBtuG6xZ6Z4506nR4lmHPTqVRwxT6KgtWC97CA==",
+			"version": "4.13.1",
+			"resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.13.1.tgz",
+			"integrity": "sha512-TTWFx+ZhyDx1Biiez2nB0L3YrCZ/8oHagaDalbuBSlqXgUPsdkUSzJsVxeDO9LtPB49+Fh3WQl3slABo6AotNw==",
 			"dev": true,
 			"requires": {
 				"async-foreach": "^0.1.3",
@@ -7865,6 +10150,14 @@
 				"sass-graph": "^2.2.4",
 				"stdout-stream": "^1.4.0",
 				"true-case-path": "^1.0.2"
+			},
+			"dependencies": {
+				"get-stdin": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+					"integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
+					"dev": true
+				}
 			}
 		},
 		"nopt": {
@@ -7990,12 +10283,6 @@
 					"requires": {
 						"is-descriptor": "^0.1.0"
 					}
-				},
-				"is-buffer": {
-					"version": "1.1.6",
-					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-					"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-					"dev": true
 				},
 				"kind-of": {
 					"version": "3.2.2",
@@ -8214,6 +10501,12 @@
 				"os-tmpdir": "^1.0.0"
 			}
 		},
+		"p-cancelable": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
+			"integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==",
+			"dev": true
+		},
 		"p-defer": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
@@ -8271,10 +10564,30 @@
 			"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
 			"dev": true
 		},
+		"package-json": {
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/package-json/-/package-json-6.5.0.tgz",
+			"integrity": "sha512-k3bdm2n25tkyxcjSKzB5x8kfVxlMdgsbPr0GkZcwHsLpba6cBjqCt1KlcChKEvxHIcTB1FVMuwoijZ26xex5MQ==",
+			"dev": true,
+			"requires": {
+				"got": "^9.6.0",
+				"registry-auth-token": "^4.0.0",
+				"registry-url": "^5.0.0",
+				"semver": "^6.2.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
+				}
+			}
+		},
 		"pako": {
-			"version": "1.0.10",
-			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.10.tgz",
-			"integrity": "sha512-0DTvPVU3ed8+HNXOu5Bs+o//Mbdj9VNQMUOe9oKCwh8l0GNwpTDMKCWbRjgtD291AWnkAgkqA/LOnQS8AmS1tw==",
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+			"integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
 			"dev": true
 		},
 		"parallel-transform": {
@@ -8480,9 +10793,9 @@
 					}
 				},
 				"p-limit": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
-					"integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
+					"version": "2.2.2",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
+					"integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
 					"dev": true,
 					"requires": {
 						"p-try": "^2.0.0"
@@ -8508,26 +10821,6 @@
 					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
 					"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
 					"dev": true
-				}
-			}
-		},
-		"pkg-up": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-2.0.0.tgz",
-			"integrity": "sha1-yBmscoBZpGHKscOImivjxJoATX8=",
-			"dev": true,
-			"requires": {
-				"find-up": "^2.1.0"
-			},
-			"dependencies": {
-				"find-up": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-					"dev": true,
-					"requires": {
-						"locate-path": "^2.0.0"
-					}
 				}
 			}
 		},
@@ -8566,9 +10859,9 @@
 			"dev": true
 		},
 		"postcss": {
-			"version": "7.0.26",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.26.tgz",
-			"integrity": "sha512-IY4oRjpXWYshuTDFxMVkJDtWIk2LhsTlu8bZnbEJA4+bYT16Lvpo8Qv6EvDumhYRgzjZl489pmsY3qVgJQ08nA==",
+			"version": "7.0.27",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.27.tgz",
+			"integrity": "sha512-WuQETPMcW9Uf1/22HWUWP9lgsIC+KEHg2kozMflKjbeUtw9ujvFX6QmIfozaErDkmLWS9WEnEdEe6Uo9/BNTdQ==",
 			"dev": true,
 			"requires": {
 				"chalk": "^2.4.2",
@@ -8625,40 +10918,14 @@
 			}
 		},
 		"postcss-calc": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-7.0.1.tgz",
-			"integrity": "sha512-oXqx0m6tb4N3JGdmeMSc/i91KppbYsFZKdH0xMOqK8V1rJlzrKlTdokz8ozUXLVejydRN6u2IddxpcijRj2FqQ==",
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-7.0.2.tgz",
+			"integrity": "sha512-rofZFHUg6ZIrvRwPeFktv06GdbDYLcGqh9EwiMutZg+a0oePCCw1zHOEiji6LCpyRcjTREtPASuUqeAvYlEVvQ==",
 			"dev": true,
 			"requires": {
-				"css-unit-converter": "^1.1.1",
-				"postcss": "^7.0.5",
-				"postcss-selector-parser": "^5.0.0-rc.4",
-				"postcss-value-parser": "^3.3.1"
-			},
-			"dependencies": {
-				"cssesc": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/cssesc/-/cssesc-2.0.0.tgz",
-					"integrity": "sha512-MsCAG1z9lPdoO/IUMLSBWBSVxVtJ1395VGIQ+Fc2gNdkQ1hNDnQdw3YhA71WJCBW1vdwA0cAnk/DnW6bqoEUYg==",
-					"dev": true
-				},
-				"postcss-selector-parser": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz",
-					"integrity": "sha512-w+zLE5Jhg6Liz8+rQOWEAwtwkyqpfnmsinXjXg6cY7YIONZZtgvE0v2O0uhQBs0peNomOJwWRKt6JBfTdTd3OQ==",
-					"dev": true,
-					"requires": {
-						"cssesc": "^2.0.0",
-						"indexes-of": "^1.0.1",
-						"uniq": "^1.0.1"
-					}
-				},
-				"postcss-value-parser": {
-					"version": "3.3.1",
-					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-					"integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
-					"dev": true
-				}
+				"postcss": "^7.0.27",
+				"postcss-selector-parser": "^6.0.2",
+				"postcss-value-parser": "^4.0.2"
 			}
 		},
 		"postcss-colormin": {
@@ -8806,12 +11073,12 @@
 			},
 			"dependencies": {
 				"postcss-selector-parser": {
-					"version": "3.1.1",
-					"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz",
-					"integrity": "sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=",
+					"version": "3.1.2",
+					"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.2.tgz",
+					"integrity": "sha512-h7fJ/5uWuRVyOtkO45pnt1Ih40CEleeyCHzipqAZO2e5H20g25Y48uYnFUiShvY4rZWNJ/Bib/KVPmanaCtOhA==",
 					"dev": true,
 					"requires": {
-						"dot-prop": "^4.1.1",
+						"dot-prop": "^5.2.0",
 						"indexes-of": "^1.0.1",
 						"uniq": "^1.0.1"
 					}
@@ -8891,12 +11158,12 @@
 			},
 			"dependencies": {
 				"postcss-selector-parser": {
-					"version": "3.1.1",
-					"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz",
-					"integrity": "sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=",
+					"version": "3.1.2",
+					"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.2.tgz",
+					"integrity": "sha512-h7fJ/5uWuRVyOtkO45pnt1Ih40CEleeyCHzipqAZO2e5H20g25Y48uYnFUiShvY4rZWNJ/Bib/KVPmanaCtOhA==",
 					"dev": true,
 					"requires": {
-						"dot-prop": "^4.1.1",
+						"dot-prop": "^5.2.0",
 						"indexes-of": "^1.0.1",
 						"uniq": "^1.0.1"
 					}
@@ -9172,12 +11439,12 @@
 			}
 		},
 		"postcss-safe-parser": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-4.0.1.tgz",
-			"integrity": "sha512-xZsFA3uX8MO3yAda03QrG3/Eg1LN3EPfjjf07vke/46HERLZyHrTsQ9E1r1w1W//fWEhtYNndo2hQplN2cVpCQ==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-4.0.2.tgz",
+			"integrity": "sha512-Uw6ekxSWNLCPesSv/cmqf2bY/77z11O7jZGPax3ycZMFU/oi2DMH9i89AdHc1tRwFg/arFoEwX0IS3LCUxJh1g==",
 			"dev": true,
 			"requires": {
-				"postcss": "^7.0.0"
+				"postcss": "^7.0.26"
 			}
 		},
 		"postcss-selector-parser": {
@@ -9223,9 +11490,9 @@
 			}
 		},
 		"postcss-value-parser": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.0.2.tgz",
-			"integrity": "sha512-LmeoohTpp/K4UiyQCwuGWlONxXamGzCMtFxLq4W1nZVGIQLYvMCJx3yAF9qyyuFpflABI9yVdtJAqbihOsCsJQ==",
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.0.3.tgz",
+			"integrity": "sha512-N7h4pG+Nnu5BEIzyeaaIYWs0LI5XC40OrRh5L60z0QjFsqGWcHcbkBvpe1WYpcIS9yQ8sOi/vIPt1ejQCrMVrg==",
 			"dev": true
 		},
 		"prelude-ls": {
@@ -9272,9 +11539,9 @@
 			"dev": true
 		},
 		"prismjs": {
-			"version": "1.17.1",
-			"resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.17.1.tgz",
-			"integrity": "sha512-PrEDJAFdUGbOP6xK/UsfkC5ghJsPJviKgnQOoxaDbBjwc8op68Quupwt1DeAFoG8GImPhiKXAvvsH7wDSLsu1Q==",
+			"version": "1.19.0",
+			"resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.19.0.tgz",
+			"integrity": "sha512-IVFtbW9mCWm9eOIaEkNyo2Vl4NnEifis2GQ7/MLRG5TQe6t+4Sj9J5QWI9i3v+SS43uZBlCAOn+zYTVYQcPXJw==",
 			"dev": true,
 			"requires": {
 				"clipboard": "^2.0.0"
@@ -9311,13 +11578,13 @@
 			"dev": true
 		},
 		"proxy-addr": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.5.tgz",
-			"integrity": "sha512-t/7RxHXPH6cJtP0pRG6smSr9QJidhB+3kXu0KgXnbGYMgzEnUxRQ4/LDdfOwZEMyIh3/xHb8PX3t+lfL9z+YVQ==",
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz",
+			"integrity": "sha512-dh/frvCBVmSsDYzw6n926jv974gddhkFPfiN8hPOi30Wax25QZyZEGveluCgliBnqmuM+UJmBErbAUFIoDbjOw==",
 			"dev": true,
 			"requires": {
 				"forwarded": "~0.1.2",
-				"ipaddr.js": "1.9.0"
+				"ipaddr.js": "1.9.1"
 			}
 		},
 		"prr": {
@@ -9390,6 +11657,15 @@
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
 			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
 			"dev": true
+		},
+		"pupa": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/pupa/-/pupa-2.0.1.tgz",
+			"integrity": "sha512-hEJH0s8PXLY/cdXh66tNEQGndDrIKNqNC5xmrysZy3i5C3oEoLna7YAOad+7u125+zH1HNXUmGEkrhb3c2VriA==",
+			"dev": true,
+			"requires": {
+				"escape-goat": "^2.0.0"
+			}
 		},
 		"q": {
 			"version": "1.5.1",
@@ -9477,6 +11753,26 @@
 				}
 			}
 		},
+		"rc": {
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+			"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+			"dev": true,
+			"requires": {
+				"deep-extend": "^0.6.0",
+				"ini": "~1.3.0",
+				"minimist": "^1.2.0",
+				"strip-json-comments": "~2.0.1"
+			},
+			"dependencies": {
+				"strip-json-comments": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+					"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+					"dev": true
+				}
+			}
+		},
 		"read-pkg": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
@@ -9499,9 +11795,9 @@
 			}
 		},
 		"readable-stream": {
-			"version": "2.3.6",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-			"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+			"version": "2.3.7",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+			"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
 			"dev": true,
 			"requires": {
 				"core-util-is": "~1.0.0",
@@ -9613,6 +11909,24 @@
 				"unicode-match-property-value-ecmascript": "^1.1.0"
 			}
 		},
+		"registry-auth-token": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.1.1.tgz",
+			"integrity": "sha512-9bKS7nTl9+/A1s7tnPeGrUpRcVY+LUh7bfFgzpndALdPfXQBfQV77rQVtqgUV3ti4vc/Ik81Ex8UJDWDQ12zQA==",
+			"dev": true,
+			"requires": {
+				"rc": "^1.2.8"
+			}
+		},
+		"registry-url": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/registry-url/-/registry-url-5.1.0.tgz",
+			"integrity": "sha512-8acYXXTI0AkQv6RAOjE3vOaIXZkT9wo4LOFbBKYQEEnnMNBpKqdUrI6S4NT0KPIo/WVvJ5tE/X5LF/TQUf0ekw==",
+			"dev": true,
+			"requires": {
+				"rc": "^1.2.8"
+			}
+		},
 		"regjsgen": {
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.1.tgz",
@@ -9620,9 +11934,9 @@
 			"dev": true
 		},
 		"regjsparser": {
-			"version": "0.6.2",
-			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.2.tgz",
-			"integrity": "sha512-E9ghzUtoLwDekPT0DYCp+c4h+bvuUpe6rRHCTYn6eGoqj1LgKXxT6I0Il4WbjhQkOghzi/V+y03bPKvbllL93Q==",
+			"version": "0.6.3",
+			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.3.tgz",
+			"integrity": "sha512-8uZvYbnfAtEm9Ab8NTb3hdLwL4g/LQzEYP7Xs27T96abJCCE2d6r3cPZPQEsLKy0vRSGVNG+/zVGtLr86HQduA==",
 			"dev": true,
 			"requires": {
 				"jsesc": "~0.5.0"
@@ -9713,9 +12027,9 @@
 			}
 		},
 		"request": {
-			"version": "2.88.0",
-			"resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
-			"integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+			"version": "2.88.2",
+			"resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+			"integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
 			"dev": true,
 			"requires": {
 				"aws-sign2": "~0.7.0",
@@ -9725,7 +12039,7 @@
 				"extend": "~3.0.2",
 				"forever-agent": "~0.6.1",
 				"form-data": "~2.3.2",
-				"har-validator": "~5.1.0",
+				"har-validator": "~5.1.3",
 				"http-signature": "~1.2.0",
 				"is-typedarray": "~1.0.0",
 				"isstream": "~0.1.2",
@@ -9735,7 +12049,7 @@
 				"performance-now": "^2.1.0",
 				"qs": "~6.5.2",
 				"safe-buffer": "^5.1.2",
-				"tough-cookie": "~2.4.3",
+				"tough-cookie": "~2.5.0",
 				"tunnel-agent": "^0.6.0",
 				"uuid": "^3.3.2"
 			}
@@ -9756,12 +12070,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
 			"integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
-			"dev": true
-		},
-		"reselect": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/reselect/-/reselect-3.0.1.tgz",
-			"integrity": "sha1-79qpjqdFEyTQkrKyFjpqHXqaIUc=",
 			"dev": true
 		},
 		"resolve": {
@@ -9793,6 +12101,15 @@
 			"resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
 			"integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
 			"dev": true
+		},
+		"responselike": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
+			"integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
+			"dev": true,
+			"requires": {
+				"lowercase-keys": "^1.0.0"
+			}
 		},
 		"restore-cursor": {
 			"version": "3.1.0",
@@ -9908,15 +12225,15 @@
 			}
 		},
 		"sass-loader": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-8.0.0.tgz",
-			"integrity": "sha512-+qeMu563PN7rPdit2+n5uuYVR0SSVwm0JsOUsaJXzgYcClWSlmX0iHDnmeOobPkf5kUglVot3QS6SyLyaQoJ4w==",
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-8.0.2.tgz",
+			"integrity": "sha512-7o4dbSK8/Ol2KflEmSco4jTjQoV988bM82P9CZdmo9hR3RLnvNc0ufMNdMrB0caq38JQ/FgF4/7RcbcfKzxoFQ==",
 			"dev": true,
 			"requires": {
 				"clone-deep": "^4.0.1",
 				"loader-utils": "^1.2.3",
 				"neo-async": "^2.6.1",
-				"schema-utils": "^2.1.0",
+				"schema-utils": "^2.6.1",
 				"semver": "^6.3.0"
 			},
 			"dependencies": {
@@ -9935,9 +12252,9 @@
 			"dev": true
 		},
 		"schema-utils": {
-			"version": "2.6.1",
-			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.6.1.tgz",
-			"integrity": "sha512-0WXHDs1VDJyo+Zqs9TKLKyD/h7yDpHUhEFsM2CzkICFdoX1av+GBq/J2xRTFfsQO5kBfhZzANf2VcIm84jqDbg==",
+			"version": "2.6.4",
+			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.6.4.tgz",
+			"integrity": "sha512-VNjcaUxVnEeun6B2fiiUDjXXBtD4ZSH7pdbfIu1pOFwgptDPLMo/z9jr4sUfsjFVPqDCEin/F7IYlq7/E6yDbQ==",
 			"dev": true,
 			"requires": {
 				"ajv": "^6.10.2",
@@ -10002,6 +12319,23 @@
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
 			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
 			"dev": true
+		},
+		"semver-diff": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-3.1.1.tgz",
+			"integrity": "sha512-GX0Ix/CJcHyB8c4ykpHGIAvLyOwOobtM/8d+TQkAd81/bEjgPHrfba41Vpesr7jX/t8Uh+R3EX9eAS5be+jQYg==",
+			"dev": true,
+			"requires": {
+				"semver": "^6.3.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
+				}
+			}
 		},
 		"send": {
 			"version": "0.17.1",
@@ -10372,12 +12706,6 @@
 				"kind-of": "^3.2.0"
 			},
 			"dependencies": {
-				"is-buffer": {
-					"version": "1.1.6",
-					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-					"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-					"dev": true
-				},
 				"kind-of": {
 					"version": "3.2.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
@@ -10592,9 +12920,9 @@
 					"dev": true
 				},
 				"readable-stream": {
-					"version": "3.4.0",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
-					"integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
 					"dev": true,
 					"requires": {
 						"inherits": "^2.0.3",
@@ -10824,6 +13152,14 @@
 			"dev": true,
 			"requires": {
 				"get-stdin": "^4.0.1"
+			},
+			"dependencies": {
+				"get-stdin": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+					"integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
+					"dev": true
+				}
 			}
 		},
 		"strip-json-comments": {
@@ -10844,12 +13180,12 @@
 			},
 			"dependencies": {
 				"postcss-selector-parser": {
-					"version": "3.1.1",
-					"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz",
-					"integrity": "sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=",
+					"version": "3.1.2",
+					"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.2.tgz",
+					"integrity": "sha512-h7fJ/5uWuRVyOtkO45pnt1Ih40CEleeyCHzipqAZO2e5H20g25Y48uYnFUiShvY4rZWNJ/Bib/KVPmanaCtOhA==",
 					"dev": true,
 					"requires": {
-						"dot-prop": "^4.1.1",
+						"dot-prop": "^5.2.0",
 						"indexes-of": "^1.0.1",
 						"uniq": "^1.0.1"
 					}
@@ -10962,9 +13298,9 @@
 			}
 		},
 		"sweetalert2": {
-			"version": "9.7.1",
-			"resolved": "https://registry.npmjs.org/sweetalert2/-/sweetalert2-9.7.1.tgz",
-			"integrity": "sha512-ytBEyqRmZQsEFuPsYcuEXpruj9AgT32ELEBWGnioflsqbxHMMM8/Ghm1+hi4hsZ1PU7cp9TFFWe06WveGfwWKw=="
+			"version": "9.8.2",
+			"resolved": "https://registry.npmjs.org/sweetalert2/-/sweetalert2-9.8.2.tgz",
+			"integrity": "sha512-Lr7DbVi/uNwQ9LOJXt9N5JZkJT0Tga9bCGfPbtnm9Gwfhs/Wthp8vSrtE+x9kjMSpvlkvoPO7TDFxoP0jFnDow=="
 		},
 		"table": {
 			"version": "5.4.6",
@@ -11029,10 +13365,16 @@
 				"inherits": "2"
 			}
 		},
+		"term-size": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/term-size/-/term-size-2.2.0.tgz",
+			"integrity": "sha512-a6sumDlzyHVJWb8+YofY4TW112G6p2FCPEAFk+59gIYHv3XHRhm9ltVQ9kli4hNWeQBwSpe8cRN25x0ROunMOw==",
+			"dev": true
+		},
 		"terser": {
-			"version": "4.4.3",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-4.4.3.tgz",
-			"integrity": "sha512-0ikKraVtRDKGzHrzkCv5rUNDzqlhmhowOBqC0XqUHFpW+vJ45+20/IFBcebwKfiS2Z9fJin6Eo+F1zLZsxi8RA==",
+			"version": "4.6.4",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-4.6.4.tgz",
+			"integrity": "sha512-5fqgBPLgVHZ/fVvqRhhUp9YUiGXhFJ9ZkrZWD9vQtFBR4QIGTnbsb+/kKqSqfgp3WnBwGWAFnedGTtmX1YTn0w==",
 			"dev": true,
 			"requires": {
 				"commander": "^2.20.0",
@@ -11176,12 +13518,6 @@
 				"kind-of": "^3.0.2"
 			},
 			"dependencies": {
-				"is-buffer": {
-					"version": "1.1.6",
-					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-					"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-					"dev": true
-				},
 				"kind-of": {
 					"version": "3.2.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
@@ -11192,6 +13528,12 @@
 					}
 				}
 			}
+		},
+		"to-readable-stream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
+			"integrity": "sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q==",
+			"dev": true
 		},
 		"to-regex": {
 			"version": "3.0.2",
@@ -11234,21 +13576,13 @@
 			"dev": true
 		},
 		"tough-cookie": {
-			"version": "2.4.3",
-			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
-			"integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+			"integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
 			"dev": true,
 			"requires": {
-				"psl": "^1.1.24",
-				"punycode": "^1.4.1"
-			},
-			"dependencies": {
-				"punycode": {
-					"version": "1.4.1",
-					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-					"dev": true
-				}
+				"psl": "^1.1.28",
+				"punycode": "^2.1.1"
 			}
 		},
 		"trim-newlines": {
@@ -11323,6 +13657,15 @@
 			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
 			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
 			"dev": true
+		},
+		"typedarray-to-buffer": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+			"integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+			"dev": true,
+			"requires": {
+				"is-typedarray": "^1.0.0"
+			}
 		},
 		"uc.micro": {
 			"version": "1.0.6",
@@ -11424,6 +13767,15 @@
 				"imurmurhash": "^0.1.4"
 			}
 		},
+		"unique-string": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
+			"integrity": "sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==",
+			"dev": true,
+			"requires": {
+				"crypto-random-string": "^2.0.0"
+			}
+		},
 		"universalify": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
@@ -11487,6 +13839,79 @@
 			"resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
 			"integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==",
 			"dev": true
+		},
+		"update-notifier": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-4.1.0.tgz",
+			"integrity": "sha512-w3doE1qtI0/ZmgeoDoARmI5fjDoT93IfKgEGqm26dGUOh8oNpaSTsGNdYRN/SjOuo10jcJGwkEL3mroKzktkew==",
+			"dev": true,
+			"requires": {
+				"boxen": "^4.2.0",
+				"chalk": "^3.0.0",
+				"configstore": "^5.0.1",
+				"has-yarn": "^2.1.0",
+				"import-lazy": "^2.1.0",
+				"is-ci": "^2.0.0",
+				"is-installed-globally": "^0.3.1",
+				"is-npm": "^4.0.0",
+				"is-yarn-global": "^0.3.0",
+				"latest-version": "^5.0.0",
+				"pupa": "^2.0.1",
+				"semver-diff": "^3.1.1",
+				"xdg-basedir": "^4.0.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"dev": true,
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
+			}
 		},
 		"upper-case": {
 			"version": "1.1.3",
@@ -11561,6 +13986,15 @@
 				"requires-port": "^1.0.0"
 			}
 		},
+		"url-parse-lax": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
+			"integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
+			"dev": true,
+			"requires": {
+				"prepend-http": "^2.0.0"
+			}
+		},
 		"use": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
@@ -11591,13 +14025,36 @@
 			"dev": true
 		},
 		"util.promisify": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
-			"integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.1.tgz",
+			"integrity": "sha512-g9JpC/3He3bm38zsLupWryXHoEcS22YHthuPQSJdMy6KNrzIRzWqcsHzD/WUnqe45whVou4VIsPew37DoXWNrA==",
 			"dev": true,
 			"requires": {
-				"define-properties": "^1.1.2",
-				"object.getownpropertydescriptors": "^2.0.3"
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.17.2",
+				"has-symbols": "^1.0.1",
+				"object.getownpropertydescriptors": "^2.1.0"
+			},
+			"dependencies": {
+				"es-abstract": {
+					"version": "1.17.4",
+					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.4.tgz",
+					"integrity": "sha512-Ae3um/gb8F0mui/jPL+QiqmglkUsaQf7FwBEHYIFkztkneosu9imhqHpBzQ3h1vit8t5iQ74t6PEVvphBZiuiQ==",
+					"dev": true,
+					"requires": {
+						"es-to-primitive": "^1.2.1",
+						"function-bind": "^1.1.1",
+						"has": "^1.0.3",
+						"has-symbols": "^1.0.1",
+						"is-callable": "^1.1.5",
+						"is-regex": "^1.0.5",
+						"object-inspect": "^1.7.0",
+						"object-keys": "^1.1.1",
+						"object.assign": "^4.1.0",
+						"string.prototype.trimleft": "^2.1.1",
+						"string.prototype.trimright": "^2.1.1"
+					}
+				}
 			}
 		},
 		"utila": {
@@ -11613,9 +14070,9 @@
 			"dev": true
 		},
 		"uuid": {
-			"version": "3.3.3",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
-			"integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==",
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+			"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
 			"dev": true
 		},
 		"v8-compile-cache": {
@@ -11641,9 +14098,9 @@
 			"dev": true
 		},
 		"vendors": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/vendors/-/vendors-1.0.3.tgz",
-			"integrity": "sha512-fOi47nsJP5Wqefa43kyWSg80qF+Q3XA6MUkgi7Hp1HQaKDQW4cQrK2D0P7mmbFtsV1N89am55Yru/nyEwRubcw==",
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/vendors/-/vendors-1.0.4.tgz",
+			"integrity": "sha512-/juG65kTL4Cy2su4P8HjtkTxk6VmJDiOPBufWniqQ6wknac6jNiXS9vU+hO3wgusiyqWlzTbVHi0dyJqRONg3w==",
 			"dev": true
 		},
 		"verror": {
@@ -11726,9 +14183,9 @@
 			"dev": true
 		},
 		"vue-loader": {
-			"version": "15.8.3",
-			"resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-15.8.3.tgz",
-			"integrity": "sha512-yFksTFbhp+lxlm92DrKdpVIWMpranXnTEuGSc0oW+Gk43M9LWaAmBTnfj5+FCdve715mTHvo78IdaXf5TbiTJg==",
+			"version": "15.9.0",
+			"resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-15.9.0.tgz",
+			"integrity": "sha512-FeDHvTSpwyLeF7LIV1PYkvqUQgTJ8UmOxhSlCyRSxaXCKk+M6NF4tDQsLsPPNeDPyR7TfRQ8MLg6v+8PsDV9xQ==",
 			"dev": true,
 			"requires": {
 				"@vue/component-compiler-utils": "^3.1.0",
@@ -11739,9 +14196,9 @@
 			}
 		},
 		"vue-router": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/vue-router/-/vue-router-3.1.3.tgz",
-			"integrity": "sha512-8iSa4mGNXBjyuSZFCCO4fiKfvzqk+mhL0lnKuGcQtO1eoj8nq3CmbEG8FwK5QqoqwDgsjsf1GDuisDX4cdb/aQ==",
+			"version": "3.1.6",
+			"resolved": "https://registry.npmjs.org/vue-router/-/vue-router-3.1.6.tgz",
+			"integrity": "sha512-GYhn2ynaZlysZMkFE5oCHRUTqE8BWs/a9YbKpNLi0i7xD6KG1EzDqpHQmv1F5gXjr8kL5iIVS8EOtRaVUEXTqA==",
 			"dev": true
 		},
 		"vue-server-renderer": {
@@ -11779,9 +14236,9 @@
 			}
 		},
 		"vue-sweetalert2": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/vue-sweetalert2/-/vue-sweetalert2-3.0.1.tgz",
-			"integrity": "sha512-njjJeqvwX/lQSVRcteafD/0VV5C66RT5awbZELfet93o71+HnYrQY4n3eU8DB8WYaSBvCKtgaoEjlk3lqHYM4w==",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/vue-sweetalert2/-/vue-sweetalert2-3.0.3.tgz",
+			"integrity": "sha512-8gEUfz6z2qJ7oQ8Bn5O9MJ+FRD53q+ziJouNh/SQ9Gx2v6WuRb8DB9tZMKGXR8YZip4CDVvSn8dh254YU2SCPg==",
 			"requires": {
 				"sweetalert2": "9.x"
 			}
@@ -11803,16 +14260,17 @@
 			"dev": true
 		},
 		"vuepress": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/vuepress/-/vuepress-1.2.0.tgz",
-			"integrity": "sha512-EfHo8Cc73qo+1Pm18hM0qOGynmDr8q5fu2664obynsdCJ1zpvoShVnA0Msraw4SI2xDc0iAoIb3dTwxUIM8DAw==",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/vuepress/-/vuepress-1.3.1.tgz",
+			"integrity": "sha512-i0f0JB0zdmdVH8P8cO4w7PljPQpf8ObiVk/1pOidvMQCMEhFmIpYz+730Wlf0rtB/GG4QUsqQ27Ckp5Rfob+hQ==",
 			"dev": true,
 			"requires": {
-				"@vuepress/core": "^1.2.0",
-				"@vuepress/theme-default": "^1.2.0",
-				"cac": "^6.3.9",
+				"@vuepress/core": "^1.3.1",
+				"@vuepress/theme-default": "^1.3.1",
+				"cac": "^6.5.6",
 				"envinfo": "^7.2.0",
-				"opencollective-postinstall": "^2.0.2"
+				"opencollective-postinstall": "^2.0.2",
+				"update-notifier": "^4.0.0"
 			}
 		},
 		"vuepress-html-webpack-plugin": {
@@ -11836,6 +14294,12 @@
 					"integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==",
 					"dev": true
 				},
+				"emojis-list": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
+					"integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
+					"dev": true
+				},
 				"json5": {
 					"version": "0.5.1",
 					"resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
@@ -11852,6 +14316,16 @@
 						"emojis-list": "^2.0.0",
 						"json5": "^0.5.0",
 						"object-assign": "^4.0.1"
+					}
+				},
+				"util.promisify": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
+					"integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
+					"dev": true,
+					"requires": {
+						"define-properties": "^1.1.2",
+						"object.getownpropertydescriptors": "^2.0.3"
 					}
 				}
 			}
@@ -11901,9 +14375,9 @@
 			}
 		},
 		"webpack": {
-			"version": "4.41.5",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-4.41.5.tgz",
-			"integrity": "sha512-wp0Co4vpyumnp3KlkmpM5LWuzvZYayDwM2n17EHFr4qxBBbRokC7DJawPJC7TfSFZ9HZ6GsdH40EBj4UV0nmpw==",
+			"version": "4.41.6",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-4.41.6.tgz",
+			"integrity": "sha512-yxXfV0Zv9WMGRD+QexkZzmGIh54bsvEs+9aRWxnN8erLWEOehAKUTeNBoUbA6HPEZPlRo7KDi2ZcNveoZgK9MA==",
 			"dev": true,
 			"requires": {
 				"@webassemblyjs/ast": "1.8.5",
@@ -11945,13 +14419,21 @@
 			}
 		},
 		"webpack-chain": {
-			"version": "4.12.1",
-			"resolved": "https://registry.npmjs.org/webpack-chain/-/webpack-chain-4.12.1.tgz",
-			"integrity": "sha512-BCfKo2YkDe2ByqkEWe1Rw+zko4LsyS75LVr29C6xIrxAg9JHJ4pl8kaIZ396SUSNp6b4815dRZPSTAS8LlURRQ==",
+			"version": "6.4.0",
+			"resolved": "https://registry.npmjs.org/webpack-chain/-/webpack-chain-6.4.0.tgz",
+			"integrity": "sha512-f97PYqxU+9/u0IUqp/ekAHRhBD1IQwhBv3wlJo2nvyELpr2vNnUqO3XQEk+qneg0uWGP54iciotszpjfnEExFA==",
 			"dev": true,
 			"requires": {
 				"deepmerge": "^1.5.2",
-				"javascript-stringify": "^1.6.0"
+				"javascript-stringify": "^2.0.1"
+			},
+			"dependencies": {
+				"javascript-stringify": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/javascript-stringify/-/javascript-stringify-2.0.1.tgz",
+					"integrity": "sha512-yV+gqbd5vaOYjqlbk16EG89xB5udgjqQF3C5FAORDg4f/IS1Yc5ERCv5e/57yBcfJYw05V5JyIXabhwb75Xxow==",
+					"dev": true
+				}
 			}
 		},
 		"webpack-dev-middleware": {
@@ -11968,9 +14450,9 @@
 			}
 		},
 		"webpack-dev-server": {
-			"version": "3.10.1",
-			"resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.10.1.tgz",
-			"integrity": "sha512-AGG4+XrrXn4rbZUueyNrQgO4KGnol+0wm3MPdqGLmmA+NofZl3blZQKxZ9BND6RDNuvAK9OMYClhjOSnxpWRoA==",
+			"version": "3.10.3",
+			"resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.10.3.tgz",
+			"integrity": "sha512-e4nWev8YzEVNdOMcNzNeCN947sWJNd43E5XvsJzbAL08kGc2frm1tQ32hTJslRS+H65LCb/AaUCYU7fjHCpDeQ==",
 			"dev": true,
 			"requires": {
 				"ansi-html": "0.0.7",
@@ -12115,9 +14597,9 @@
 					}
 				},
 				"p-limit": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
-					"integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
+					"version": "2.2.2",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
+					"integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
 					"dev": true,
 					"requires": {
 						"p-try": "^2.0.0"
@@ -12403,6 +14885,55 @@
 				"string-width": "^1.0.2 || 2"
 			}
 		},
+		"widest-line": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
+			"integrity": "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==",
+			"dev": true,
+			"requires": {
+				"string-width": "^4.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+					"dev": true
+				},
+				"emoji-regex": {
+					"version": "8.0.0",
+					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+					"dev": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+					"dev": true
+				},
+				"string-width": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+					"integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+					"dev": true,
+					"requires": {
+						"emoji-regex": "^8.0.0",
+						"is-fullwidth-code-point": "^3.0.0",
+						"strip-ansi": "^6.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^5.0.0"
+					}
+				}
+			}
+		},
 		"word-wrap": {
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
@@ -12443,6 +14974,18 @@
 				"mkdirp": "^0.5.1"
 			}
 		},
+		"write-file-atomic": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
+			"integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
+			"dev": true,
+			"requires": {
+				"imurmurhash": "^0.1.4",
+				"is-typedarray": "^1.0.0",
+				"signal-exit": "^3.0.2",
+				"typedarray-to-buffer": "^3.1.5"
+			}
+		},
 		"ws": {
 			"version": "6.2.1",
 			"resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
@@ -12451,6 +14994,12 @@
 			"requires": {
 				"async-limiter": "~1.0.0"
 			}
+		},
+		"xdg-basedir": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
+			"integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==",
+			"dev": true
 		},
 		"xtend": {
 			"version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -12,28 +12,28 @@
 	},
 	"private": true,
 	"devDependencies": {
-		"@vuepress/plugin-back-to-top": "^1.2.0",
-		"@vuepress/plugin-google-analytics": "^1.2.0",
+		"@vuepress/plugin-back-to-top": "^1.3.1",
+		"@vuepress/plugin-google-analytics": "^1.3.1",
 		"eslint": "^6.8.0",
 		"eslint-config-airbnb": "^18.0.1",
-		"eslint-config-prettier": "^6.9.0",
+		"eslint-config-prettier": "^6.10.0",
 		"eslint-config-vuepress": "^2.1.0",
 		"eslint-plugin-prettier": "^3.1.2",
-		"node-sass": "^4.13.0",
+		"node-sass": "^4.13.1",
 		"prettier": "^1.19.1",
-		"sass-loader": "^8.0.0",
+		"sass-loader": "^8.0.2",
 		"vue-agile": "^1.0.11",
-		"vuepress": "^1.2.0",
+		"vuepress": "^1.3.1",
 		"vuepress-plugin-clean-urls": "^1.1.1",
 		"vuepress-plugin-container": "^2.1.2"
 	},
 	"dependencies": {
-		"@mdi/font": "^4.7.95",
-		"axios": "^0.19.1",
+		"@mdi/font": "^4.9.95",
+		"axios": "^0.19.2",
 		"iso-639-1": "^2.1.0",
 		"lodash.groupby": "^4.6.0",
 		"lodash.sortby": "^4.7.0",
 		"material-design-icons": "^3.0.1",
-		"vue-sweetalert2": "^3.0.1"
+		"vue-sweetalert2": "^3.0.3"
 	}
 }

--- a/src/.vuepress/components/DownloadButtons.vue
+++ b/src/.vuepress/components/DownloadButtons.vue
@@ -1,102 +1,11 @@
 <template>
-	<ul class="download-list">
-		<li>
-			<a
-				class="download-link"
-				rel="noopener noreferrer"
-				:href="
-					browserDownloadUrl ||
-						'https://github.com/inorichi/tachiyomi/releases/latest'
-				"
-				:title="tagName"
-				download
-			>
-				<div class="download-button stable">
-					<span class="download-area">
-						<MaterialIcon
-							name="download-cloud_download download-icons"
-							icon-name="cloud_download"
-						/>
-						<span class="download-text-stable download-text"
-							>Stable release</span
-						>
-					</span>
-				</div>
-			</a>
-		</li>
-		<li>
-			<a class="download-link" href="http://tachiyomi.kanade.eu/latest">
-				<div class="download-button dev">
-					<div class="download-area">
-						<MaterialIcon
-							name="download-bug_report download-icons"
-							icon-name="bug_report"
-						/>
-						<span class="download-text-dev download-text"
-							>Dev release</span
-						>
-					</div>
-				</div>
-			</a>
-		</li>
-	</ul>
+	<div class="downloadContainer">
+		<button class="downloadStableButton" @click="downloadStable">
+			Stable
+		</button>
+		<button class="downloadDevButton" @click="downloadDev">Dev</button>
+	</div>
 </template>
-
-<style scoped lang="stylus">
-*
-	font-family $buttonFontFamily
-
-ul
-	margin 0.625em 0 0
-	padding 0
-	text-align center
-	user-select none
-	width 100%
-
-li
-	display inline-block
-	margin 0.3125em 0.625em
-
-a.download-link
-	&:hover
-		text-decoration none
-	.download-button
-		align-items center
-		background-color $accentColor
-		border-radius $buttonBorderRadius
-		cursor pointer
-		display flex
-		height 3.75em
-		justify-content center
-		padding 0 1em
-		width 11.25em
-		&.stable
-			background-color $accentColor
-			&:hover
-				filter brightness(110%)
-		&.dev
-			background-color $accentColorSecondary
-			&:hover
-				filter brightness(110%)
-		.download-area
-			align-items center
-			color #ffffff
-			display flex
-			font-size 1.125em
-			.download-icons
-				color #ffffff
-				font-size 0.875em
-				max-width 2em
-			.download-cloud_download
-				margin-left 0.2em
-				margin-right 0.5em
-			.download-bug_report
-				margin-right 0.25em
-			.download-text-stable
-				margin-right 0.375em
-			.download-text-dev
-				margin-right 0.05em
-</style>
 
 <script>
 import axios from "axios";
@@ -119,6 +28,48 @@ export default {
 		// Set the values.
 		this.$data.tagName = data.tag_name;
 		this.$data.browserDownloadUrl = apkAsset.browser_download_url;
+	},
+
+	methods: {
+		downloadStable() {
+			window.location.assign(
+				this.$data.browserDownloadUrl || RELEASE_URL
+			);
+			window.ga("send", "event", "Button", "Click", "Stable download");
+		},
+		downloadDev() {
+			window.location.assign("http://tachiyomi.kanade.eu/latest");
+			window.ga("send", "event", "Button", "Click", "Dev download");
+		}
 	}
 };
 </script>
+
+<style lang="stylus">
+.downloadContainer
+	user-select none
+	text-align center
+	margin 0.3125rem
+	.downloadStableButton
+	.downloadDevButton
+		border-style none
+		padding 11.25px 36px
+		margin 0.3125rem
+		border-radius $buttonBorderRadius
+		font-family $buttonFontFamily
+		font-size 1.125em
+		color white
+		height 3rem
+		width 8.5rem
+		&:focus
+			outline none
+			outline-style solid
+		&:hover
+			cursor pointer
+			text-decoration none !important
+			background-image linear-gradient(rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0.1))
+	.downloadStableButton
+		background-color $accentColor
+	.downloadDevButton
+		background-color $accentColorSecondary
+</style>

--- a/src/.vuepress/components/DownloadButtons.vue
+++ b/src/.vuepress/components/DownloadButtons.vue
@@ -35,11 +35,11 @@ export default {
 	methods: {
 		downloadStable() {
 			window.location.assign(this.$data.browserDownloadUrl || RELEASE_URL);
-			window.ga("send", "event", "Button", "Click", "Stable download");
+			window.ga("send", "event", "Button", "Click", "Stable download - Getting Started");
 		},
 		downloadDev() {
 			window.location.assign("http://tachiyomi.kanade.eu/latest");
-			window.ga("send", "event", "Button", "Click", "Dev download");
+			window.ga("send", "event", "Button", "Click", "Dev download - Getting Started");
 		}
 	}
 };

--- a/src/.vuepress/components/DownloadButtons.vue
+++ b/src/.vuepress/components/DownloadButtons.vue
@@ -57,25 +57,25 @@ export default {
 			window.ga("send", "event", "Button", "Click", "Stable download - Getting Started");
 		},
 		downloadDev() {
-		this.$swal({
-			title: "Downloading",
-			text: "Dev version is being downloaded.",
-			icon: "success",
-			focusConfirm: false,
-			focusCancel: false,
-			timer: 5000,
-			timerProgressBar: true,
-			customClass: {
-				confirmButton: "download-confirm-button",
-				container: "download-container"
-			},
-			showClass: {
-				popup: "animated pulse faster"
-			},
-			hideClass: {
-				popup: "animated zoomOut faster"
-			}
-		});
+			this.$swal({
+				title: "Downloading",
+				text: "Dev version is being downloaded.",
+				icon: "success",
+				focusConfirm: false,
+				focusCancel: false,
+				timer: 5000,
+				timerProgressBar: true,
+				customClass: {
+					confirmButton: "download-confirm-button",
+					container: "download-container"
+				},
+				showClass: {
+					popup: "animated pulse faster"
+				},
+				hideClass: {
+					popup: "animated zoomOut faster"
+				}
+			});
 			window.location.assign("http://tachiyomi.kanade.eu/latest");
 			window.ga("send", "event", "Button", "Click", "Dev download - Getting Started");
 		}

--- a/src/.vuepress/components/DownloadButtons.vue
+++ b/src/.vuepress/components/DownloadButtons.vue
@@ -34,10 +34,48 @@ export default {
 
 	methods: {
 		downloadStable() {
+			this.$swal({
+				title: "Downloading",
+				text: "Stable version is being downloaded.",
+				icon: "success",
+				focusConfirm: false,
+				focusCancel: false,
+				timer: 5000,
+				timerProgressBar: true,
+				customClass: {
+					confirmButton: "download-confirm-button",
+					container: "download-container"
+				},
+				showClass: {
+					popup: "animated pulse faster"
+				},
+				hideClass: {
+					popup: "animated zoomOut faster"
+				}
+			});
 			window.location.assign(this.$data.browserDownloadUrl || RELEASE_URL);
 			window.ga("send", "event", "Button", "Click", "Stable download - Getting Started");
 		},
 		downloadDev() {
+		this.$swal({
+			title: "Downloading",
+			text: "Dev version is being downloaded.",
+			icon: "success",
+			focusConfirm: false,
+			focusCancel: false,
+			timer: 5000,
+			timerProgressBar: true,
+			customClass: {
+				confirmButton: "download-confirm-button",
+				container: "download-container"
+			},
+			showClass: {
+				popup: "animated pulse faster"
+			},
+			hideClass: {
+				popup: "animated zoomOut faster"
+			}
+		});
 			window.location.assign("http://tachiyomi.kanade.eu/latest");
 			window.ga("send", "event", "Button", "Click", "Dev download - Getting Started");
 		}

--- a/src/.vuepress/components/DownloadButtons.vue
+++ b/src/.vuepress/components/DownloadButtons.vue
@@ -3,7 +3,9 @@
 		<button class="downloadStableButton" @click="downloadStable">
 			Stable
 		</button>
-		<button class="downloadDevButton" @click="downloadDev">Dev</button>
+		<button class="downloadDevButton" @click="downloadDev">
+			Dev
+		</button>
 	</div>
 </template>
 
@@ -32,9 +34,7 @@ export default {
 
 	methods: {
 		downloadStable() {
-			window.location.assign(
-				this.$data.browserDownloadUrl || RELEASE_URL
-			);
+			window.location.assign(this.$data.browserDownloadUrl || RELEASE_URL);
 			window.ga("send", "event", "Button", "Click", "Stable download");
 		},
 		downloadDev() {
@@ -53,7 +53,7 @@ export default {
 	.downloadStableButton
 	.downloadDevButton
 		border-style none
-		padding 11.25px 36px
+		padding 0.625 2em
 		margin 0.3125rem
 		border-radius $buttonBorderRadius
 		font-family $buttonFontFamily

--- a/src/.vuepress/theme/components/Home.vue
+++ b/src/.vuepress/theme/components/Home.vue
@@ -133,7 +133,13 @@ export default {
 						this.$data.browserDownloadUrl ||
 							"https://github.com/inorichi/tachiyomi/releases/latest"
 					);
-					ga("send", "event", "Button", "Click", "Stable download");
+					window.ga(
+						"send",
+						"event",
+						"Button",
+						"Click",
+						"Stable download"
+					);
 				} else if (result.dismiss === "cancel") {
 					this.$swal({
 						title: "Downloading",
@@ -155,7 +161,13 @@ export default {
 						}
 					});
 					window.location.assign("http://tachiyomi.kanade.eu/latest");
-					ga("send", "event", "Button", "Click", "Dev download");
+					window.ga(
+						"send",
+						"event",
+						"Button",
+						"Click",
+						"Dev download"
+					);
 				}
 			});
 		}

--- a/src/.vuepress/theme/components/Home.vue
+++ b/src/.vuepress/theme/components/Home.vue
@@ -133,6 +133,7 @@ export default {
 						this.$data.browserDownloadUrl ||
 							"https://github.com/inorichi/tachiyomi/releases/latest"
 					);
+					ga("send", "event", "Button", "Click", "Stable download");
 				} else if (result.dismiss === "cancel") {
 					this.$swal({
 						title: "Downloading",
@@ -154,6 +155,7 @@ export default {
 						}
 					});
 					window.location.assign("http://tachiyomi.kanade.eu/latest");
+					ga("send", "event", "Button", "Click", "Dev download");
 				}
 			});
 		}

--- a/src/help/guides/getting-started.md
+++ b/src/help/guides/getting-started.md
@@ -9,17 +9,14 @@ lang: en-US
 
 <DownloadButtons/>
 
-You can download the latest version of `Tachiyomi` from the [GitHub releases](https://github.com/inorichi/tachiyomi/releases/latest).
+You can download the latest version of **Tachiyomi** from any of the above buttons.
 
-<Badge text="tachiyomi-vX.Y.Z.apk"/>
+If you want to try new features before they get to the stable release, you can download the dev version.
 
-
-If you want to try new features before they get to the stable release, you can download the dev version [here](http://tachiyomi.kanade.eu/latest).
-
-Open and install the `.apk` file you just downloaded from GitHub.
+Open and install the `.apk` file you just downloaded.
 
 <figure class="centered">
-	<img height="145" intrinsicsize="1000x500" width="300"
+	<img height="128"
 	  :src="$withBase('/assets/media/installprompt.png')">
 </figure>
 


### PR DESCRIPTION
_Attempts_ to add ("Debugging the `ga();` tag was difficult in localhost") tags for tracking download events.

I haven't been able to try this as GA don't at all want to function in localhost. This is the correct implementation I'm pretty sure though.

If this doesn't work then I read that it might require switching from the GA Plugin to a standard `.js` script with GA Global Tag support.

Also updates dependencies alongside it.