### PR TITLE
Fix text overflow on index

### DIFF
--- a/src/.vuepress/styles/index.styl
+++ b/src/.vuepress/styles/index.styl
@@ -136,7 +136,7 @@ font-feature-settings()
 	.feature
 		text-align center
 		p
-			max-height 5em
+			min-height 4em
 		img
 			max-height 28em
 			max-width 100%

--- a/src/.vuepress/styles/index.styl
+++ b/src/.vuepress/styles/index.styl
@@ -136,7 +136,7 @@ font-feature-settings()
 	.feature
 		text-align center
 		p
-			height 5em
+			max-height 5em
 		img
 			max-height 28em
 			max-width 100%


### PR DESCRIPTION
Fix text overflow on index like @joseph619 experienced when using 120% font scaling on phone browser.

Solved by instead of having a set `height: 5em` I changed it to `min-height: 4em` so that it want to stay a uniform size but can be increased.

Prevents this:
![image](https://user-images.githubusercontent.com/10836780/75955294-dc84be80-5eb5-11ea-816e-84e79fa8d1d5.png)
