### PR TITLE
Update GitHub Push actions

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,14 +1,16 @@
 name: Build and deploy website
+
 on:
   push:
     branches:
       - master
+
 jobs:
-  deploy:
+  build-deploy:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
 
       - name: Install Node v12
         uses: actions/setup-node@v1
@@ -20,12 +22,15 @@ jobs:
           npm install
           npm run build
 
-      - name: Add nojekyll
+      - name: Add .nojekyll
         run: touch ./public/.nojekyll
 
       - name: Deploy website
-        uses: peaceiris/actions-gh-pages@v2.3.0
-        env:
-          ACTIONS_DEPLOY_KEY: ${{ secrets.ACTIONS_DEPLOY_KEY }}
-          PUBLISH_BRANCH: gh-pages
-          PUBLISH_DIR: ./public
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
+          publish_branch: gh-pages
+          publish_dir: ./public
+          user_name: 'github-actions[bot]'
+          user_email: 'github-actions[bot]@users.noreply.github.com'
+          commit_message: ${{ github.event.head_commit.message }}


### PR DESCRIPTION
**Changes**
- Updated "actions/checkout" from v1 to v2.
- Updated "peaceiris/actions-gh-pages" from v2.3.0 to v3.
- Cleaned up the "gh-pages" commit messages.
- Small cleanup.

Example before/after with the commit messages:
![comparison](https://user-images.githubusercontent.com/10836780/77118462-8aef3e80-6a34-11ea-88cc-a3a28794ce12.png)

This was also done to avoid confusion on the `#github-website` channel where your (Arkon) name is stated every time a build is deployed:
![image](https://user-images.githubusercontent.com/10836780/77118532-ac502a80-6a34-11ea-9381-68775c3aba37.png)