### PR TITLE
Add Spreadsheet to Extensions Page

### DIFF
--- a/src/extensions/README.md
+++ b/src/extensions/README.md
@@ -7,4 +7,10 @@ lang: en-US
 
 Here is a list of all available extensions to download inside the app.
 
+::: guide
+User [SnakeDoc83](https://github.com/snakedoc83) has made a handy spreadsheet showing the different mulit-source extensions and their sources.
+::: aside
+[Click here to access the spreadsheet](https://docs.google.com/spreadsheets/d/1TyJEUg78WWH4zgnf3g6M2lkbWpBWbd40FYiPVQhW8IU/edit#gid=0)
+:::
+
 <ExtensionList/>

--- a/src/help/faq/extensions.md
+++ b/src/help/faq/extensions.md
@@ -133,7 +133,7 @@ It means that the respective extension for the manga is not installed. To fix, i
 #### Value Manga is licensed at data of type java.lang.String cannot be converted to JSONObject
 This means that the manga has been licensed and can no longer be read on that source. Try a different source to read the manga.
 
-#### HTTP error 503
+#### HTTP error 403
 The source you selected may have Cloudflare protection on and is enforcing CAPTCHAs.
 
 1. Find a manga in your library that is from the source you're trying to access


### PR DESCRIPTION
Closes #127 

Also, Cloudflare Captcha is a http `403` rather than a `503`. 
503 is normally seen with the I'm under attack / automatic browser check which errors out as `Failed to bypass cloudflare`. 