### PR TITLE
Update MaterialIcon.vue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2686,11 +2686,6 @@
 				"to-fast-properties": "^2.0.0"
 			}
 		},
-		"@mdi/font": {
-			"version": "5.1.45",
-			"resolved": "https://registry.npmjs.org/@mdi/font/-/font-5.1.45.tgz",
-			"integrity": "sha512-7H1UMwUpEp8mthdPlpAi7bhEyvTbvtK1TlA89scc0cXMpQy0UFygdkaf+6fveIxpBcRNgw0gnGSEonlsfYocXg=="
-		},
 		"@mrmlnc/readdir-enhanced": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
 		"vuepress-plugin-container": "^2.1.3"
 	},
 	"dependencies": {
-		"@mdi/font": "^5.1.45",
 		"axios": "^0.19.2",
 		"iso-639-1": "^2.1.1",
 		"lodash.groupby": "^4.6.0",

--- a/src/.vuepress/components/MaterialIcon.vue
+++ b/src/.vuepress/components/MaterialIcon.vue
@@ -1,8 +1,5 @@
 <template>
-	<i v-if="iconOnly" class="material-icons">{{ iconName }}</i>
-	<div v-else-if="legacy" :class="name" class="material-holder">
-		<i :class="iconName" class="material-legacy-icons mdi"></i>
-	</div>
+	<i v-if="iconOnly" :class="name" class="material-icons">{{ iconName }}</i>
 	<div v-else :class="name" class="material-holder">
 		<i class="material-icons">{{ iconName }}</i>
 	</div>
@@ -12,17 +9,10 @@
 /**
  * For material icon references use https://material.io/resources/icons/
  * Code example: <MaterialIcon iconName="android" />
- *
- * For material icon references use https://materialdesignicons.com/
- * Code example: <MaterialIcon iconName="mdi-glasses" legacy />
  */
 export default {
 	props: {
 		iconOnly: {
-			type: Boolean,
-			default: false
-		},
-		legacy: {
 			type: Boolean,
 			default: false
 		},
@@ -63,8 +53,4 @@ export default {
 	font-feature-settings 'liga'
 	-webkit-font-smoothing antialiased
 
-.material-legacy-icons
-	font-family 'Material Design Icons'
-	font-size 1.35em
-	font-style normal
 </style>

--- a/src/.vuepress/styles/fonts.styl
+++ b/src/.vuepress/styles/fonts.styl
@@ -4,8 +4,3 @@
 	font-weight 400
 	src url('~material-design-icons/iconfont/MaterialIcons-Regular.eot')
 	src local('Material Icons'), local('MaterialIcons-Regular'), url('~material-design-icons/iconfont/MaterialIcons-Regular.woff2') format('woff2'), url('~material-design-icons/iconfont/MaterialIcons-Regular.woff') format('woff'), url('~material-design-icons/iconfont/MaterialIcons-Regular.ttf') format('truetype'), url('~material-design-icons/iconfont/MaterialIcons-Regular.svg#MaterialIcons-Regular') format('svg')
-
-@font-face
-	font-family 'Material Design Icons'
-	src url('~@mdi/font/fonts/materialdesignicons-webfont.eot')
-	src local('Material Design Icons'), local('Material-Design-Icons'), url('~@mdi/font/fonts/materialdesignicons-webfont.woff2') format('woff2'), url('~@mdi/font/fonts/materialdesignicons-webfont.woff') format('woff'), url('~@mdi/font/fonts/materialdesignicons-webfont.ttf') format('truetype')


### PR DESCRIPTION
Removes Material Design Icons because it doesn't work, and didn't find anything that uses it.
Also, added the ability to style iconOnly flag.


Before (Upper left material icon, upper right iconOnly material icon, lower part MDI):
![image](https://user-images.githubusercontent.com/6576096/80758913-b5094580-8b36-11ea-8b81-44fa46ff63be.png)
After:
![image](https://user-images.githubusercontent.com/6576096/80759125-13cebf00-8b37-11ea-94dd-7389c2608f8f.png)

