### PR TITLE
Fixed typo that broke anchors.

### DIFF
--- a/src/.vuepress/components/ExtensionList.vue
+++ b/src/.vuepress/components/ExtensionList.vue
@@ -67,7 +67,7 @@ export default {
 	},
 
 	updated() {
-		if (window.ocation.hash) {
+		if (window.location.hash) {
 			window.location.replace(window.location.hash);
 		}
 	},


### PR DESCRIPTION
Title. 

Anchors are currently broken. For [example](https://tachiyomi.org/extensions/#ComiCake), this won't jump.

Fixed in the deploy [preview](https://deploy-preview-268--tachiyomi.netlify.app/extensions/#ComiCake).