### PR TITLE
Create global constants file

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -23,7 +23,9 @@
 		"markdown"
 	],
 	"rules": {
-		"prettier/prettier": "error",
+		"prettier/prettier": ["error", {
+		   "endOfLine":"auto"
+		 }],
 		"import/no-unresolved": [
 			2,
 			{ "ignore": ["^@"] }

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,7 +1,8 @@
 {
 	"tabWidth": 4,
 	"useTabs": true,
+	"printWidth": 120,
 	"trailingComma": "es5",
 	"bracketSpacing": true,
-	"endOfLine": "lf"
+	"endOfLine": "auto"
 }

--- a/src/.vuepress/components/DownloadButtons.vue
+++ b/src/.vuepress/components/DownloadButtons.vue
@@ -11,11 +11,8 @@
 
 <script>
 import axios from "axios";
-
-const RELEASE_URL =
-	"https://api.github.com/repos/inorichi/tachiyomi/releases/latest";
-
-const PREVIEW_URL = "https://tachiyomi.kanade.eu/latest";
+// eslint-disable-next-line prettier/prettier
+import { githubLatestApi, githubLatestRelease, kanadeLatest } from "../constants";
 
 export default {
 	props: {
@@ -53,7 +50,7 @@ export default {
 	},
 
 	async mounted() {
-		const { data } = await axios.get(RELEASE_URL);
+		const { data } = await axios.get(githubLatestApi);
 		// Maybe eventually some release has more than the apk in assets.
 		const apkAsset = data.assets.find((a) => a.name.includes(".apk"));
 		// Set the values.
@@ -85,7 +82,7 @@ export default {
 			window.location.assign(
 				this.$props.downloadStableUrl ||
 					this.$data.browserDownloadUrl ||
-					RELEASE_URL
+					githubLatestRelease
 			);
 			window.ga(
 				"send",
@@ -116,7 +113,7 @@ export default {
 				},
 			});
 			window.location.assign(
-				this.$props.downloadPreviewUrl || PREVIEW_URL
+				this.$props.downloadPreviewUrl || kanadeLatest
 			);
 			window.ga(
 				"send",

--- a/src/.vuepress/components/DownloadButtons.vue
+++ b/src/.vuepress/components/DownloadButtons.vue
@@ -11,7 +11,6 @@
 
 <script>
 import axios from "axios";
-// eslint-disable-next-line prettier/prettier
 import { githubLatestApi, githubLatestRelease, kanadeLatest } from "../constants";
 
 export default {

--- a/src/.vuepress/components/DownloadButtons.vue
+++ b/src/.vuepress/components/DownloadButtons.vue
@@ -11,7 +11,7 @@
 
 <script>
 import axios from "axios";
-import { githubLatestApi, githubLatestRelease, kanadeLatest } from "../constants";
+import { GITHUB_LATEST_API, GITHUB_LATEST_RELEASE, KANADE_LATEST } from "../constants";
 
 export default {
 	props: {
@@ -49,7 +49,7 @@ export default {
 	},
 
 	async mounted() {
-		const { data } = await axios.get(githubLatestApi);
+		const { data } = await axios.get(GITHUB_LATEST_API);
 		// Maybe eventually some release has more than the apk in assets.
 		const apkAsset = data.assets.find((a) => a.name.includes(".apk"));
 		// Set the values.
@@ -81,7 +81,7 @@ export default {
 			window.location.assign(
 				this.$props.downloadStableUrl ||
 					this.$data.browserDownloadUrl ||
-					githubLatestRelease
+					GITHUB_LATEST_RELEASE
 			);
 			window.ga(
 				"send",
@@ -112,7 +112,7 @@ export default {
 				},
 			});
 			window.location.assign(
-				this.$props.downloadPreviewUrl || kanadeLatest
+				this.$props.downloadPreviewUrl || KANADE_LATEST
 			);
 			window.ga(
 				"send",

--- a/src/.vuepress/components/ExtensionList.vue
+++ b/src/.vuepress/components/ExtensionList.vue
@@ -47,8 +47,6 @@ import axios from "axios";
 import groupBy from "lodash.groupby";
 import sortBy from "lodash.sortby";
 import ISO6391 from "iso-639-1";
-
-// eslint-disable-next-line prettier/prettier
 import { githubExtensionJson } from "../constants";
 
 export default {

--- a/src/.vuepress/components/ExtensionList.vue
+++ b/src/.vuepress/components/ExtensionList.vue
@@ -48,8 +48,8 @@ import groupBy from "lodash.groupby";
 import sortBy from "lodash.sortby";
 import ISO6391 from "iso-639-1";
 
-const EXTENSION_JSON =
-	"https://raw.githubusercontent.com/inorichi/tachiyomi-extensions/repo/index.json";
+// eslint-disable-next-line prettier/prettier
+import { githubExtensionJson } from "../constants";
 
 export default {
 	data() {
@@ -59,7 +59,7 @@ export default {
 	},
 
 	async beforeMount() {
-		const { data } = await axios.get(EXTENSION_JSON);
+		const { data } = await axios.get(githubExtensionJson);
 		const values = Object.values(groupBy(data, "lang"));
 		this.$data.extensions = sortBy(values, [
 			(g) => this.langName(g[0].lang),

--- a/src/.vuepress/components/ExtensionList.vue
+++ b/src/.vuepress/components/ExtensionList.vue
@@ -47,7 +47,7 @@ import axios from "axios";
 import groupBy from "lodash.groupby";
 import sortBy from "lodash.sortby";
 import ISO6391 from "iso-639-1";
-import { githubExtensionJson } from "../constants";
+import { GITHUB_EXTENSION_JSON } from "../constants";
 
 export default {
 	data() {
@@ -57,7 +57,7 @@ export default {
 	},
 
 	async beforeMount() {
-		const { data } = await axios.get(githubExtensionJson);
+		const { data } = await axios.get(GITHUB_EXTENSION_JSON);
 		const values = Object.values(groupBy(data, "lang"));
 		this.$data.extensions = sortBy(values, [
 			(g) => this.langName(g[0].lang),

--- a/src/.vuepress/components/ReleaseNotes.vue
+++ b/src/.vuepress/components/ReleaseNotes.vue
@@ -6,8 +6,8 @@
 import axios from "axios";
 import marked from "marked";
 
-const RELEASE_URL =
-	"https://api.github.com/repos/inorichi/tachiyomi/releases/latest";
+// eslint-disable-next-line prettier/prettier
+import { githubLatestApi } from "../constants";
 
 export default {
 	data() {
@@ -17,7 +17,7 @@ export default {
 	},
 
 	async mounted() {
-		const { data } = await axios.get(RELEASE_URL);
+		const { data } = await axios.get(githubLatestApi);
 		this.$data.releaseNotes = marked(data.body);
 	},
 };

--- a/src/.vuepress/components/ReleaseNotes.vue
+++ b/src/.vuepress/components/ReleaseNotes.vue
@@ -5,7 +5,7 @@
 <script>
 import axios from "axios";
 import marked from "marked";
-import { githubLatestApi } from "../constants";
+import { GITHUB_LATEST_API } from "../constants";
 
 export default {
 	data() {
@@ -15,7 +15,7 @@ export default {
 	},
 
 	async mounted() {
-		const { data } = await axios.get(githubLatestApi);
+		const { data } = await axios.get(GITHUB_LATEST_API);
 		this.$data.releaseNotes = marked(data.body);
 	},
 };

--- a/src/.vuepress/components/ReleaseNotes.vue
+++ b/src/.vuepress/components/ReleaseNotes.vue
@@ -5,8 +5,6 @@
 <script>
 import axios from "axios";
 import marked from "marked";
-
-// eslint-disable-next-line prettier/prettier
 import { githubLatestApi } from "../constants";
 
 export default {

--- a/src/.vuepress/components/VersionTag.vue
+++ b/src/.vuepress/components/VersionTag.vue
@@ -11,8 +11,6 @@
 
 <script>
 import axios from "axios";
-
-// eslint-disable-next-line prettier/prettier
 import { githubLatestApi } from "../constants";
 
 export default {

--- a/src/.vuepress/components/VersionTag.vue
+++ b/src/.vuepress/components/VersionTag.vue
@@ -12,8 +12,8 @@
 <script>
 import axios from "axios";
 
-const RELEASE_URL =
-	"https://api.github.com/repos/inorichi/tachiyomi/releases/latest";
+// eslint-disable-next-line prettier/prettier
+import { githubLatestApi } from "../constants";
 
 export default {
 	props: {
@@ -29,7 +29,7 @@ export default {
 	},
 
 	async mounted() {
-		const { data } = await axios.get(RELEASE_URL);
+		const { data } = await axios.get(githubLatestApi);
 		// Set the values.
 		this.$data.tagName = data.tag_name;
 	},

--- a/src/.vuepress/components/VersionTag.vue
+++ b/src/.vuepress/components/VersionTag.vue
@@ -11,7 +11,7 @@
 
 <script>
 import axios from "axios";
-import { githubLatestApi } from "../constants";
+import { GITHUB_LATEST_API } from "../constants";
 
 export default {
 	props: {
@@ -27,7 +27,7 @@ export default {
 	},
 
 	async mounted() {
-		const { data } = await axios.get(githubLatestApi);
+		const { data } = await axios.get(GITHUB_LATEST_API);
 		// Set the values.
 		this.$data.tagName = data.tag_name;
 	},

--- a/src/.vuepress/constants.js
+++ b/src/.vuepress/constants.js
@@ -1,5 +1,4 @@
-/* eslint-disable prettier/prettier */
-export const githubExtensionJson = "https://raw.githubusercontent.com/inorichi/tachiyomi-extensions/repo/index.json"
-export const githubLatestRelease = "https://github.com/inorichi/tachiyomi/releases/latest";
-export const githubLatestApi = "https://api.github.com/repos/inorichi/tachiyomi/releases/latest";
-export const kanadeLatest = "https://tachiyomi.kanade.eu/latest";
+export const GITHUB_EXTENSION_JSON = "https://raw.githubusercontent.com/inorichi/tachiyomi-extensions/repo/index.json";
+export const GITHUB_LATEST_RELEASE = "https://github.com/inorichi/tachiyomi/releases/latest";
+export const GITHUB_LATEST_API = "https://api.github.com/repos/inorichi/tachiyomi/releases/latest";
+export const KANADE_LATEST = "https://tachiyomi.kanade.eu/latest";

--- a/src/.vuepress/constants.js
+++ b/src/.vuepress/constants.js
@@ -1,0 +1,5 @@
+/* eslint-disable prettier/prettier */
+export const githubExtensionJson = "https://raw.githubusercontent.com/inorichi/tachiyomi-extensions/repo/index.json"
+export const githubLatestRelease = "https://github.com/inorichi/tachiyomi/releases/latest";
+export const githubLatestApi = "https://api.github.com/repos/inorichi/tachiyomi/releases/latest";
+export const kanadeLatest = "https://tachiyomi.kanade.eu/latest";

--- a/src/.vuepress/theme/components/Home.vue
+++ b/src/.vuepress/theme/components/Home.vue
@@ -84,12 +84,8 @@ import axios from "axios";
 import CloudDownloadIcon from "vue-material-design-icons/CloudDownload.vue";
 import BookOpenVariantIcon from "vue-material-design-icons/BookOpenVariant.vue";
 
-const RELEASE_URL =
-	"https://api.github.com/repos/inorichi/tachiyomi/releases/latest";
-
-const LATEST_RELEASE = "https://github.com/inorichi/tachiyomi/releases/latest";
-
-const PREVIEW_URL = "https://tachiyomi.kanade.eu/latest";
+// eslint-disable-next-line prettier/prettier
+import { githubLatestApi, githubLatestRelease, kanadeLatest } from "../../constants";
 
 export default {
 	name: "Home",
@@ -126,7 +122,7 @@ export default {
 	},
 
 	async mounted() {
-		const { data } = await axios.get(RELEASE_URL);
+		const { data } = await axios.get(githubLatestApi);
 		const apkAsset = data.assets.find((a) => a.name.includes(".apk"));
 		this.$data.tagName = data.tag_name;
 		this.$data.browserDownloadUrl = apkAsset.browser_download_url;
@@ -194,7 +190,7 @@ export default {
 						},
 					});
 					window.location.assign(
-						this.$data.browserDownloadUrl || LATEST_RELEASE
+						this.$data.browserDownloadUrl || githubLatestRelease
 					);
 					window.ga(
 						"send",
@@ -263,7 +259,7 @@ export default {
 										"animate__animated animate__faster animate__zoomOut",
 								},
 							});
-							window.location.assign(PREVIEW_URL);
+							window.location.assign(kanadeLatest);
 							window.ga(
 								"send",
 								"event",

--- a/src/.vuepress/theme/components/Home.vue
+++ b/src/.vuepress/theme/components/Home.vue
@@ -80,11 +80,8 @@
 
 <script>
 import axios from "axios";
-
 import CloudDownloadIcon from "vue-material-design-icons/CloudDownload.vue";
 import BookOpenVariantIcon from "vue-material-design-icons/BookOpenVariant.vue";
-
-// eslint-disable-next-line prettier/prettier
 import { githubLatestApi, githubLatestRelease, kanadeLatest } from "../../constants";
 
 export default {

--- a/src/.vuepress/theme/components/Home.vue
+++ b/src/.vuepress/theme/components/Home.vue
@@ -82,7 +82,7 @@
 import axios from "axios";
 import CloudDownloadIcon from "vue-material-design-icons/CloudDownload.vue";
 import BookOpenVariantIcon from "vue-material-design-icons/BookOpenVariant.vue";
-import { githubLatestApi, githubLatestRelease, kanadeLatest } from "../../constants";
+import { GITHUB_LATEST_API, GITHUB_LATEST_RELEASE, KANADE_LATEST } from "../../constants";
 
 export default {
 	name: "Home",
@@ -119,7 +119,7 @@ export default {
 	},
 
 	async mounted() {
-		const { data } = await axios.get(githubLatestApi);
+		const { data } = await axios.get(GITHUB_LATEST_API);
 		const apkAsset = data.assets.find((a) => a.name.includes(".apk"));
 		this.$data.tagName = data.tag_name;
 		this.$data.browserDownloadUrl = apkAsset.browser_download_url;
@@ -187,7 +187,7 @@ export default {
 						},
 					});
 					window.location.assign(
-						this.$data.browserDownloadUrl || githubLatestRelease
+						this.$data.browserDownloadUrl || GITHUB_LATEST_RELEASE
 					);
 					window.ga(
 						"send",
@@ -256,7 +256,7 @@ export default {
 										"animate__animated animate__faster animate__zoomOut",
 								},
 							});
-							window.location.assign(kanadeLatest);
+							window.location.assign(KANADE_LATEST);
 							window.ga(
 								"send",
 								"event",


### PR DESCRIPTION
Instead of having all files use their own `const` of the re-used assets such as URLs for download, put them in a global `constants.js` file and import to each file when needed.