### PR TITLE
Adds mobile tooltips for Download page

### DIFF
--- a/src/.vuepress/components/ReleaseDate.vue
+++ b/src/.vuepress/components/ReleaseDate.vue
@@ -1,6 +1,6 @@
 <template>
 	<div v-if="stable" class="buildTime">
-		<el-tooltip placement="top" open-delay="250" effect="light">
+		<el-tooltip placement="top" open-delay="250">
 			<div slot="content">
 				<strong>{{ stablePublishExact }}</strong>
 			</div>
@@ -8,7 +8,7 @@
 		</el-tooltip>
 	</div>
 	<div v-else-if="preview" class="buildTime">
-		<el-tooltip placement="bottom-end" open-delay="250" effect="light">
+		<el-tooltip placement="bottom-end" open-delay="250">
 			<div slot="content">
 				<strong>{{ previewPublishExact }}</strong>
 			</div>

--- a/src/.vuepress/components/ReleaseDate.vue
+++ b/src/.vuepress/components/ReleaseDate.vue
@@ -1,9 +1,19 @@
 <template>
 	<div v-if="stable" class="buildTime">
-		<span :title="stablePublishExact">{{ stablePublishRelative }}</span>
+		<el-tooltip placement="top" open-delay="250" effect="light">
+			<div slot="content">
+				<strong>{{ stablePublishExact }}</strong>
+			</div>
+			<span>{{ stablePublishRelative }}</span>
+		</el-tooltip>
 	</div>
 	<div v-else-if="preview" class="buildTime">
-		<span :title="previewPublishExact">{{ previewPublishRelative }}</span>
+		<el-tooltip placement="bottom-end" open-delay="250" effect="light">
+			<div slot="content">
+				<strong>{{ previewPublishExact }}</strong>
+			</div>
+			<span>{{ previewPublishRelative }}</span>
+		</el-tooltip>
 	</div>
 	<span v-else>You need to specify props.</span>
 </template>


### PR DESCRIPTION
As the title suggests, users on mobile can now tap the relative date for an exact date as a tooltip.