### PR TITLE
Redirect user to GitHub instead of API when they have slow internet

### DIFF
--- a/src/.vuepress/components/ForkButtons.vue
+++ b/src/.vuepress/components/ForkButtons.vue
@@ -3,7 +3,7 @@
 		<button class="downloadForkButton" :style="downloadForkStyle" @click="downloadFork">
 			{{ downloadForkLabel }}
 		</button>
-		<button class="githubForkButton" :style="githubForkStyle" :onclick="githubForkLink">
+		<button class="githubForkButton" :style="githubForkStyle" :onclick="'window.open(\''+githubForkLink+'\')'">
 			{{ githubForkLabel }}
 		</button>
 		<br />
@@ -90,7 +90,7 @@ export default {
 					popup: "animated zoomOut faster",
 				},
 			});
-			window.location.assign(this.$data.browserDownloadUrl || this.$props.downloadForkLink);
+			window.location.assign(this.$data.browserDownloadUrl || (this.$props.githubForkLink + "/releases/latest"));
 			window.ga("send", "event", "Action", "Download", this.$props.forkName);
 		},
 	},

--- a/src/forks/Neko.md
+++ b/src/forks/Neko.md
@@ -16,7 +16,7 @@ sidebar: false
 
 # <img class="headerLogo" :src="$withBase('/assets/forks_logo-neko.png')"> Neko
 
-<ForkButtons forkName="Neko" downloadForkLink="https://api.github.com/repos/CarlosEsco/Neko/releases/latest" downloadForkStyle="background-color:#3DDA83;color:#000000;" githubForkLink="window.open('https://github.com/CarlosEsco/Neko')" androidVersion="7.0"/>
+<ForkButtons forkName="Neko" downloadForkLink="https://api.github.com/repos/CarlosEsco/Neko/releases/latest" downloadForkStyle="background-color:#3DDA83;color:#000000;" githubForkLink="https://github.com/CarlosEsco/Neko" androidVersion="7.0"/>
 
 ## About
 This is a [MangaDex](https://mangadex.org/) specific fork of **Tachiyomi** and [TachiyomiJ2K](/forks/TachiyomiJ2K). This contains features specific to **MangaDex** that those versions cannot offer. It also features almost every feature that **J2K** has except for extensions (aka other sources), custom covers, and local manga.

--- a/src/forks/TachiyomiAZ.md
+++ b/src/forks/TachiyomiAZ.md
@@ -82,7 +82,7 @@ sidebar: false
 
 # <img class="headerLogo" :src="$withBase('/assets/forks_logo-az.png')"> TachiyomiAZ
 
-<ForkButtons forkName="TachiyomiAZ" downloadForkLink="https://api.github.com/repos/az4521/TachiyomiAZ/releases/latest" downloadForkStyle="background-color:#FFCC4D;color:#000000;" githubForkLink="window.open('https://github.com/az4521/TachiyomiAZ')"/>
+<ForkButtons forkName="TachiyomiAZ" downloadForkLink="https://api.github.com/repos/az4521/TachiyomiAZ/releases/latest" downloadForkStyle="background-color:#FFCC4D;color:#000000;" githubForkLink="https://github.com/az4521/TachiyomiAZ"/>
 <div class="overflowContainer">
   <div class="textLoop">
     <div class="textWiggle">

--- a/src/forks/TachiyomiEH.md
+++ b/src/forks/TachiyomiEH.md
@@ -16,7 +16,7 @@ sidebar: false
 
 # <img class="headerLogo" :src="$withBase('/assets/forks_logo-eh.png')"> TachiyomiEH <Badge text="Deprecated" type="error" vertical="middle" />
 
-<ForkButtons forkName="TachiyomiEH" downloadForkLink="https://api.github.com/repos/NerdNumber9/TachiyomiEH/releases/latest" githubForkLink="window.open('https://github.com/NerdNumber9/TachiyomiEH')"/>
+<ForkButtons forkName="TachiyomiEH" downloadForkLink="https://api.github.com/repos/NerdNumber9/TachiyomiEH/releases/latest" githubForkLink="https://github.com/NerdNumber9/TachiyomiEH"/>
 
 ## Introduction
 **TachiyomiEH** is maintained by **[NerdNumber9](https://github.com/NerdNumber9)**.

--- a/src/forks/TachiyomiJ2K.md
+++ b/src/forks/TachiyomiJ2K.md
@@ -16,7 +16,7 @@ sidebar: false
 
 # <img class="headerLogo" :src="$withBase('/assets/forks_logo-j2k.png')"> TachiyomiJ2K
 
-<ForkButtons forkName="TachiyomiJ2K" downloadForkLink="https://api.github.com/repos/Jays2Kings/tachiyomiJ2K/releases/latest" githubForkLink="window.open('https://github.com/Jays2Kings/tachiyomiJ2K')" androidVersion="6.0"/>
+<ForkButtons forkName="TachiyomiJ2K" downloadForkLink="https://api.github.com/repos/Jays2Kings/tachiyomiJ2K/releases/latest" githubForkLink="https://github.com/Jays2Kings/tachiyomiJ2K" androidVersion="6.0"/>
 
 ## Introduction
 **TachiyomiJ2K** is maintained by **[Jays2Kings](https://github.com/Jays2Kings)**.

--- a/src/forks/TachiyomiSY.md
+++ b/src/forks/TachiyomiSY.md
@@ -16,7 +16,7 @@ sidebar: false
 
 # <img class="headerLogo" :src="$withBase('/assets/forks_logo-sy.png')"> TachiyomiSY
 
-<ForkButtons forkName="TachiyomiSY" downloadForkLink="https://api.github.com/repos/jobobby04/TachiyomiSY/releases/latest" downloadForkStyle="background-color:#BE0F6E;color:#FFFFFF;" githubForkLink="window.open('https://github.com/jobobby04/TachiyomiSY')"/>
+<ForkButtons forkName="TachiyomiSY" downloadForkLink="https://api.github.com/repos/jobobby04/TachiyomiSY/releases/latest" downloadForkStyle="background-color:#BE0F6E;color:#FFFFFF;" githubForkLink="https://github.com/jobobby04/TachiyomiSY"/>
 
 ## About
 This fork is based off of [TachiyomiAZ](/forks/TachiyomiAZ) and adds quite a few custom unique features, it also has new features from the latest **Tachiyomi** version as well as from other forks such as [TachiyomiJ2K](/forks/TachiyomiJ2K).


### PR DESCRIPTION
The issue:
https://discord.com/channels/349436576037732353/615495625231958047/775999633703960597
Could reproduce this with Chrome on Android debugging with Slow 3G 

I changed so instead of redirecting the user to the GitHub API, it redirects them to the fork latest release on GitHub.
So let's say it fails to fetch the apk download link before the user presses the download button it would redirect to https://github.com/CarlosEsco/Neko/releases/latest, instead of how it did previously it would redirect to https://api.github.com/repos/CarlosEsco/Neko/releases/latest

