### PR TITLE
Clarify local folder location

### DIFF
--- a/src/help/guides/reading-local-manga.md
+++ b/src/help/guides/reading-local-manga.md
@@ -9,7 +9,9 @@ lang: en-US
 Follow the steps below to create local manga.
 
 1. Create a folder named `local` in the `/Tachiyomi/` folder.
-	> This is located in the phone's **internal storage** or **external SD card**.
+    <ul>
+  		<li> The `/Tachiyomi/` folder is located in the root of phone's **internal storage** or **external SD card** and it's **not related** to the `eu.kanade.tachiyomi/` folder or the download location in the settings.</li>
+    </ul> 
 1. Place correctly structured manga inside `/Tachiyomi/local/`.
 	<ul>
   		<li>Optional: If adding manga in folders, add a file named `.nomedia` to the local folder so images do not show up in the gallery</li>


### PR DESCRIPTION
Users are often confused with it, so here.

Also made it as a list item to be consistent with the item below (also because `eu.kanade.tachiyomi/` stands out too much within gray text, imo)