### PR TITLE
Update FAQ

### DIFF
--- a/src/help/faq/README.md
+++ b/src/help/faq/README.md
@@ -93,10 +93,10 @@ Set download location to default by going to <Navigation item="more"/> → <Navi
 Sometimes some covers for local manga aren't displayed. Follow these steps to fix it:
 
 ::: guide
-1. Make sure you've created right folder structure. To do it, open the manga with missing cover and check if you can read chapters in the app. If not, follow [this](/help/guides/reading-local-manga) guide first.
-1. Remember which chapters you've read and remove manga from library.
+1. Make sure you've created the right folder structure. To check it, open the manga with the missing cover and check if you can read chapters in the app. If not, follow [this](/help/guides/reading-local-manga) guide first.
+1. Remember, or note down, which chapters you've read and remove manga from the library.
 1. Go to <Navigation item="more"/> → <Navigation item="settings"/> → <Navigation item="settings_advanced"/> and tap **Clear database**. This only affects manga that aren't in your library.
-1. Go to <Navigation item="browse"/> → **Local source** and find the manga, the cover should be fixed now. Add manga back to library, mark read chapters and add tracking if needed.
+1. Go to <Navigation item="browse"/> → **Local source** and find the manga, the cover should be fixed now. Add manga back to the library, mark read chapters and add tracking if needed.
 :::
 
 ::: note

--- a/src/help/faq/README.md
+++ b/src/help/faq/README.md
@@ -93,7 +93,7 @@ Set download location to default by going to <Navigation item="more"/> → <Navi
 Sometimes some covers for local manga aren't displayed. Follow these steps to fix it:
 
 ::: guide
-1. Make sure you've created right folder structure. To do it, open the manga with missing cover and check if you can open chapters. If not, follow [this](/help/guides/reading-local-manga) guide first.
+1. Make sure you've created right folder structure. To do it, open the manga with missing cover and check if you can read chapters in the app. If not, follow [this](/help/guides/reading-local-manga) guide first.
 1. Remember which chapters you've read and remove manga from library.
 1. Go to <Navigation item="more"/> → <Navigation item="settings"/> → <Navigation item="settings_advanced"/> and tap **Clear database**. This only affects manga that aren't in your library.
 1. Go to <Navigation item="browse"/> → **Local source** and find the manga, the cover should be fixed now. Add manga back to library, mark read chapters and add tracking if needed.

--- a/src/help/faq/README.md
+++ b/src/help/faq/README.md
@@ -54,10 +54,9 @@ Aside from network issues, it could be because the images are too big or that th
 
 ### Downloads
 #### How to download several chapters or manga simultaneously?
-
-If you're downloading several manga, you can use different sources. In this case the app will start downloading simultaneously from up to 5 different sources.
-
 The app doesn't allow parallel downloads from one source to prevent IP bans caused by too many requests. We know that speed is being sacrificed but it's better than not being able to access a source at all.
+
+However, if you're downloading several manga from different sources, the app will start downloading simultaneously from up to 5 different sources.
 
 #### Why are Downloads unstable?
 Be aware that it could be a network issue on your device or on the catalog you are trying to download from.

--- a/src/help/faq/README.md
+++ b/src/help/faq/README.md
@@ -19,10 +19,10 @@ Enable it by going to <Navigation item="library"/> → <Navigation item="filter"
 :::
 
 #### Why are some covers white after restoring from backup?
-The URL to the cover has probably changed. To fix this, refresh the metadata of your library.
+The URL to the cover has probably changed. To fix this, refresh covers in settings.
 
 ::: guide
-Refresh your metadata by going to <Navigation item="more"/> → <Navigation item="settings"/> → <Navigation item="settings_advanced"/> then pressing **Refresh library metadata**.
+Refresh your covers by going to <Navigation item="more"/> → <Navigation item="settings"/> → <Navigation item="settings_advanced"/> then pressing **Refresh library manga covers**.
 :::
 
 #### How do I ignore chapters from certain scanlator groups?
@@ -53,8 +53,11 @@ If the website/scanlator group doesn't have an online manga reader, you can down
 Aside from network issues, it could be because the images are too big or that the decoder doesn't support that image type.
 
 ### Downloads
-#### What happened to the simultaneous downloads feature?
-It was removed to prevent IP bans caused by too many requests. We know that speed is being sacrificed but it's better than not being able to access a source at all.
+#### How to download several chapters or manga simultaneously?
+
+If you're downloading several manga, you can use different sources. In this case the app will start downloading simultaneously from up to 5 different sources.
+
+The app doesn't allow parallel downloads from one source to prevent IP bans caused by too many requests. We know that speed is being sacrificed but it's better than not being able to access a source at all.
 
 #### Why are Downloads unstable?
 Be aware that it could be a network issue on your device or on the catalog you are trying to download from.
@@ -70,7 +73,7 @@ Read more about rooting your phone [here](https://www.xda-developers.com/root/)
 To log in with Kitsu you need to use your email address as your username.
 
 #### Why can't I find manga in MAL's search results?
-You can search a manga from your MAL profile's list by searching in the following format: `my:<manga>`
+You can search a manga from your MAL profile's list by searching in the following format: `my:<manga>`. To search manga that isn't in your list, you can use the following format: `id:<id from manga URL>`.
 ::: note
 Related GitHub issue: [#65](https://github.com/tachiyomiorg/tachiyomi/issues/65)
 :::
@@ -80,13 +83,31 @@ Related GitHub issue: [#65](https://github.com/tachiyomiorg/tachiyomi/issues/65)
 We recommend you to read [this](/help/guides/reading-local-manga) guide on how to do so.
 
 #### What do I do if I can't find the Tachiyomi folder?
-If you don't see a **Tachiyomi** folder on your device, try downloading a chapter of any manga or creating a backup so that the folder can be created.
+If you don't see the **Tachiyomi** folder on your device, try setting download location to default and downloading a chapter of any manga so that the folder can be created.
+
+::: guide
+Set download location to default by going to <Navigation item="more"/> → <Navigation item="settings"/> → <Navigation item="settings_downloads"/> → **Download location** and selecting first option. Restart the app after changing download location.
+:::
+
+#### How to fix empty cover for a local manga?
+Sometimes some covers for local manga aren't displayed. Follow these steps to fix it:
+
+::: guide
+1. Make sure you've created right folder structure. To do it, open the manga with missing cover and check if you can open chapters. If not, follow [this](/help/guides/reading-local-manga) guide first.
+1. Remember which chapters you've read and remove manga from library.
+1. Go to <Navigation item="more"/> → <Navigation item="settings"/> → <Navigation item="settings_advanced"/> and tap **Clear database**. This only affects manga that aren't in your library.
+1. Go to <Navigation item="browse"/> → **Local source** and find the manga, the cover should be fixed now. Add manga back to library, mark read chapters and add tracking if needed.
+:::
+
+::: note
+Related GitHub issue: [#932](https://github.com/tachiyomiorg/tachiyomi/issues/932)
+:::
 
 ### Application Updates
 #### How do I enable automatic updates?
 From version **0.9.0** and onwards, Tachiyomi has automatic updates for the app enabled by default. The **Preview** version also has automatic updates enabled by default.
 
-However, if you think you are on an outdated version, go to <Navigation item="more"/> → <Navigation item="about"/> → and click on **Check for updates**.
+However, if you think you are on an outdated version, go to <Navigation item="more"/> → <Navigation item="about"/> and click on **Check for updates**.
 
 #### Why are automatic updates not working?
 
@@ -212,7 +233,7 @@ To uninstall an extension from within **Tachiyomi**, go to <Navigation item="bro
 - **Tachiyomi** no longer have pre-installed extensions, this means that you will need to install extensions you want to use from the <Navigation item="browse"/> → **Extensions** menu.
 - If you're getting the `Loader not implemented` error after clicking on a manga, you will need to reinstall the extensions you used to use.
 
-#### How do see sources of other languages?
+#### How to see sources of other languages?
 
 You do this by following the steps below.
 


### PR DESCRIPTION
- There is no **Refresh library metadata** option anymore, but instead there is **Refresh library manga covers** now.
- The app now allows parallel downloads, but only from up to 5 different sources.
- New search method in MAL (by id).
- The Tachiyomi folder isn't automatically created on install and requires some actions to be automatically created, but the actions in faq aren't good examples: download location and automatic backup location can be previously changed by the user and manual backup suggests last selected folder. I only left downloading (and added extra steps to ensure that the folder will be created in the right place), since auto-backup requires waiting and there is no default folder to revert to.
- Guide how to fix missing covers for local manga (the **Refresh library metadata** option doesn't help in this case).
- Fixed few small mistakes.