### PR TITLE
Change top margin and padding for h2

### DIFF
--- a/src/.vuepress/styles/index.styl
+++ b/src/.vuepress/styles/index.styl
@@ -43,9 +43,7 @@ a
 	h2
 		font-size 1.5rem
 		font-weight 500
-		padding-top 0rem !important
 		padding-bottom .25rem !important
-		margin-top 2rem !important
 		margin-bottom 1rem !important
 	code
 		padding .25rem .5rem


### PR DESCRIPTION
Don't know where along the lines this was changed but it failed to take in account for the navbar when going to linked titles. This fixes that.