### PR TITLE
New contributor guides

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,76 @@
+# Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+ advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+ address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+ professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at contact@tachiyomi.org. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -55,7 +55,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at contact@tachiyomi.org. All
+reported by contacting the project team at the Tachiyomi [Discord server](https://discord.gg/tachiyomi). All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Tachiyomi Contributing Guide
+# Tachiyomi Website Contributing Guide
 
 Before submitting your contribution, please make sure to take a moment and read through the following guidelines:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,91 @@
+# Tachiyomi Contributing Guide
+
+Before submitting your contribution, please make sure to take a moment and read through the following guidelines:
+
+- [Code of Conduct](../CODE_OF_CONDUCT.md)
+- [Development Setup](#development-setup)
+- [Project Structure](#project-structure)
+
+## Development Setup
+
+You will need [Node.js](http://nodejs.org) **version 12+**, and [npm](https://docs.npmjs.com/try-the-latest-stable-version-of-npm) **version 7+**.
+
+After cloning the repo, run:
+
+``` bash
+# Installs any dependencies needed.
+$ npm install
+```
+
+To run the project now, run:
+
+``` bash
+# This command start a local server you can access and edit live.
+$ npm run serve
+```
+
+### Commonly used NPM scripts
+
+``` bash
+# This command will generate a static site inside a public directory in your project.
+$ npm run build
+
+# This command will lint your files.
+$ npm run lint
+```
+
+ **Please make sure to have `npm run build` pass successfully before submitting a PR.** Although the same tests will be run against your PR on the CI server, it is better to have it working locally.
+
+## Project Structure
+
+- **`public`**: contains built files for distribution. Note this directory is only updated when a release happens or when you run the build command. Changes to this folder will not carry over with Git.
+
+- **`src`**: contains the main code files.
+
+  - **`.vuepress`**: contains the main code files.
+
+	- **`components`**: this contains all the `.vue` components used on the website.
+
+    - **`config`**: contains complementary files for `config.js`.
+
+      - `navBar.js`: config for navigation bar.
+
+      - `plugins.js`: config for plugins.
+
+      - `sideBar.js`: config for sidebar.
+
+     - **`public`**: contains the static images/videos/scripts you'll want to use for the website.
+
+     - **`store`**: this contains the data store file used to connect features like downloads to main app and its forks.
+
+     - **`styles`**: all the projects style files are contained here.
+
+     - **`theme`**: this contains the extended Vuepress theme files.
+
+    - [`config.js`](https://vuepress.vuejs.org/guide/basic-config.html#config-file): main config file for Vuepress.
+
+	- `constants.js`: all reused variables/constants is stored here.
+
+	- [`enhanceApp.js`](https://vuepress.vuejs.org/guide/basic-config.html#app-level-enhancements): this file is the place to install Vue plugins, register components and directives, etc.
+
+  - **`download`**: contains the markdown file for the `/download/` page.
+
+  - **`extensions`**: contains the markdown file for the `/extensions/` page.
+
+  - **`forks`**: contains the markdown files for the `/forks/...` pages.
+
+  - **`help`**: contains the markdown files for all the `/help/...` pages.
+
+  - **`sandbox`**: contains the markdown files for the `/sandbox/...` pages.
+
+  - `README.md`: markdown file for the front-page.
+
+- `package.json`: contains information about which plugins are installed in the project.
+
+## Credits
+
+Thank you to all the people who have already contributed!
+
+<a href="https://github.com/tachiyomiorg/website/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=tachiyomiorg/website" />
+</a>

--- a/README.md
+++ b/README.md
@@ -14,7 +14,10 @@
 
 Pull requests are welcome. For major changes, please open an issue first to discuss what you would like to change.
 
-You can find a project style guide [here](https://tachiyomi.org/sandbox/style-guide/).</br>
+- [Code of Conduct](./CODE_OF_CONDUCT.md)
+- [Contributing guide](./CONTRIBUTING.md)
+- [Project style guide](https://tachiyomi.org/sandbox/style-guide/)
+
 If you got any questions, [join our Discord server](https://discord.gg/tachiyomi).
 
 ## Repositories
@@ -22,10 +25,10 @@ If you got any questions, [join our Discord server](https://discord.gg/tachiyomi
 <div>
 	<p align="center">
 		<a href="https://github.com/tachiyomiorg/tachiyomi/">
-			<img src="https://github-readme-stats.vercel.app/api/pin/?username=tachiyomiorg&repo=tachiyomi&bg_color=0000&text_color=777" alt="Android App">
+			<img src="https://github-readme-stats.vercel.app/api/pin/?username=tachiyomiorg&repo=tachiyomi&bg_color=0000&text_color=777&hide_border=true" alt="Android App">
 		</a>
 		<a href="https://github.com/tachiyomiorg/tachiyomi-extensions/">
-			<img src="https://github-readme-stats.vercel.app/api/pin/?username=tachiyomiorg&repo=tachiyomi-extensions&bg_color=0000&text_color=777" alt="App Extensions">
+			<img src="https://github-readme-stats.vercel.app/api/pin/?username=tachiyomiorg&repo=tachiyomi-extensions&bg_color=0000&text_color=777&hide_border=true" alt="App Extensions">
 		</a>
 	</p>
 </div>
@@ -33,10 +36,10 @@ If you got any questions, [join our Discord server](https://discord.gg/tachiyomi
 <div>
 	<p align="center">
 		<a href="https://github.com/tachiyomiorg/tachiyomi-1.x/">
-			<img src="https://github-readme-stats.vercel.app/api/pin/?username=tachiyomiorg&repo=tachiyomi-1.x&bg_color=0000&text_color=777" alt="Android App (Rewrite)">
+			<img src="https://github-readme-stats.vercel.app/api/pin/?username=tachiyomiorg&repo=tachiyomi-1.x&bg_color=0000&text_color=777&hide_border=true alt="Android App (Rewrite)">
 		</a>
 		<a href="https://github.com/tachiyomiorg/tachiyomi-extensions-1.x/">
-			<img src="https://github-readme-stats.vercel.app/api/pin/?username=tachiyomiorg&repo=tachiyomi-extensions-1.x&bg_color=0000&text_color=777" alt="App Extensions (Rewrite)">
+			<img src="https://github-readme-stats.vercel.app/api/pin/?username=tachiyomiorg&repo=tachiyomi-extensions-1.x&bg_color=0000&text_color=777&hide_border=true" alt="App Extensions (Rewrite)">
 		</a>
 	</p>
 </div>
@@ -48,3 +51,11 @@ If you got any questions, [join our Discord server](https://discord.gg/tachiyomi
 	This Source Code Form is subject to the terms of the Mozilla Public
 	License, v. 2.0. If a copy of the MPL was not distributed with this
 	file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+## Credits
+
+Thank you to all the people who have already contributed!
+
+<a href="https://github.com/tachiyomiorg/website/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=tachiyomiorg/website" />
+</a>


### PR DESCRIPTION
- Adds Code of Conduct based on the Contributor Covenant.
  - Note: It uses the `contact@tachiyomi.org` e-mail.
- Adds Contributing guide.
- Tweaks to README.
  - Add a credits image generated based on contributors.
  - Remove border from repository cards.
  - Adds links to Code of Conduct and the Contributing guide.