### PR TITLE
fix incorrect link to /help/browse

### DIFF
--- a/src/help/guides/getting-started.md
+++ b/src/help/guides/getting-started.md
@@ -49,6 +49,6 @@ Check your spelling and try again, there's also the chance that your used source
 * Some sources use different wordings
   > For example **3-gatsu no Lion** instead of **Sangatsu no Lion**.
 ::: note
-Find more potential answers to your questions [here](/help/faq/#why-can-t-i-find-x-manga).
+Find more potential answers to your questions [here](/help/faq/#browse).
 :::
 ::::


### PR DESCRIPTION
previous link: /help/faq/#why-can-t-i-find-x-manga
updated link: /help/faq/#browse

link was changed in Getting Started section
Browse section has that relevant info now