### PR TITLE
[skip ci] Fix link to list of extensions in issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -7,7 +7,7 @@ contact_links:
     url: https://github.com/tachiyomiorg/tachiyomi-extensions/issues/new/choose
     about: Issues and requests for extensions and sources should be opened in the tachiyomi-extensions repository instead
   - name: 📦 Tachiyomi extensions
-    url: https://github.com/tachiyomiorg/tachiyomi-extensions
+    url: https://tachiyomi.org/extensions
     about: List of all available extensions with download links
   - name: 🖥️ Tachiyomi website
     url: https://tachiyomi.org/help/


### PR DESCRIPTION
similar to https://github.com/tachiyomiorg/tachiyomi/pull/5493