### PR TITLE
Revert "Bump marked from 3.0.4 to 3.0.6"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
 				"element-ui": "^2.15.5",
 				"lodash.groupby": "^4.6.0",
 				"lodash.sortby": "^4.7.0",
-				"marked": "^3.0.6",
+				"marked": "^3.0.4",
 				"material-design-icons-iconfont": "^6.1.0",
 				"vue": "^2.6.12",
 				"vue-agile": "^1.1.3",
@@ -10223,9 +10223,9 @@
 			"peer": true
 		},
 		"node_modules/marked": {
-			"version": "3.0.6",
-			"resolved": "https://registry.npmjs.org/marked/-/marked-3.0.6.tgz",
-			"integrity": "sha512-a1hY8eqdP9JgmsaO0MYYhO9Li2nfY/5pAj+gWU5r41Lze6AV4Xty1cseLWDcOYimJnaVfQAomaA6NK+z2IyR+w==",
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-3.0.4.tgz",
+			"integrity": "sha512-jBo8AOayNaEcvBhNobg6/BLhdsK3NvnKWJg33MAAPbvTWiG4QBn9gpW1+7RssrKu4K1dKlN+0goVQwV41xEfOA==",
 			"bin": {
 				"marked": "bin/marked"
 			},
@@ -25410,9 +25410,9 @@
 			"integrity": "sha512-TAIHTHPwa9+ltKvKPWulm/beozQU41Ab+FIefRaQV1NRnpzwcV9QOe6wXQS5WLivm5Q/nlo0rl6laGkMDZE7Gw=="
 		},
 		"marked": {
-			"version": "3.0.6",
-			"resolved": "https://registry.npmjs.org/marked/-/marked-3.0.6.tgz",
-			"integrity": "sha512-a1hY8eqdP9JgmsaO0MYYhO9Li2nfY/5pAj+gWU5r41Lze6AV4Xty1cseLWDcOYimJnaVfQAomaA6NK+z2IyR+w=="
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-3.0.4.tgz",
+			"integrity": "sha512-jBo8AOayNaEcvBhNobg6/BLhdsK3NvnKWJg33MAAPbvTWiG4QBn9gpW1+7RssrKu4K1dKlN+0goVQwV41xEfOA=="
 		},
 		"material-design-icons-iconfont": {
 			"version": "6.1.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
 		"element-ui": "^2.15.5",
 		"lodash.groupby": "^4.6.0",
 		"lodash.sortby": "^4.7.0",
-		"marked": "^3.0.6",
+		"marked": "^3.0.4",
 		"material-design-icons-iconfont": "^6.1.0",
 		"vue": "^2.6.12",
 		"vue-agile": "^1.1.3",


### PR DESCRIPTION
Reverts tachiyomiorg/website#754

Marked seems to have broken something in their latest update https://github.com/markedjs/marked/issues/2228, causes the changelog to break