### PR TITLE
Add a link to the local source JSON generator tool

### DIFF
--- a/src/help/guides/local-manga.md
+++ b/src/help/guides/local-manga.md
@@ -163,6 +163,8 @@ You can copy the following example and edit the details as needed:
 }
 ```
 
+If you don't want to manually create the `details.json` file, you can alternatively use [this tool](https://tachi-local.netlify.app/?utm_source=tachi-website&utm_medium=referral&utm_campaign=tachi-website).
+
 ### Using a custom cover image
 
 It is also possible to use a custom image as a cover for each local manga.


### PR DESCRIPTION
I created a [tool](https://tachi-local.netlify.app) that allows the user to create and edit the `details.json` for using in the local source.

I think it's interesting to link it on the website to allow the users to make use of it.

The URL have some `utm` parameters, but they can be removed if needed.