### PR TITLE
Removed the width atribute

### DIFF
--- a/src/.vuepress/theme/components/NavBar.vue
+++ b/src/.vuepress/theme/components/NavBar.vue
@@ -136,7 +136,6 @@ $navbar-horizontal-padding = 1.5rem
 		.links
 			padding-left 1.5rem
 		.site-name
-			width calc(100vw - 9.4rem)
 			overflow hidden
 			white-space nowrap
 			text-overflow ellipsis


### PR DESCRIPTION
Because of the width attribute, Tachiyomi Text moves dow
![Screenshot (78)](https://user-images.githubusercontent.com/92370865/149662429-2e7d95af-643d-4d11-922f-0eedf5de616d.jpg)
After Removing the width 
![Screenshot (79)](https://user-images.githubusercontent.com/92370865/149662482-c25ffad7-f49d-44c6-8c4e-df127c457e58.jpg)
n