### PR TITLE
fix: change selector for social links on hover

### DIFF
--- a/src/.vuepress/theme/components/PageFooter.vue
+++ b/src/.vuepress/theme/components/PageFooter.vue
@@ -82,7 +82,7 @@ export default {
 			white-space no-wrap
 		.icon.outbound
 			visibility hidden
-		&:hover
+		> :hover
 			.material-design-icon
 				color $accentColor
 				&.discord-icon


### PR DESCRIPTION
Hovering over any links in the social links footer make all links behave like they in hover state.
Changed the selector to apply hover state only on the actual element that is being hovered.

Before (hovering over Reddit):
<img width="539" alt="Screen Shot 2022-10-22 at 13 29 04" src="https://user-images.githubusercontent.com/18269880/197334356-11f73958-8092-45e8-b519-1c8258a1fba1.png">

After (hovering over Reddit):
<img width="556" alt="Screen Shot 2022-10-22 at 13 29 11" src="https://user-images.githubusercontent.com/18269880/197334357-66bcf7bc-720f-4051-9868-1cbe3178e140.png">
