### PR TITLE
Correcting a small grammatical error in the /help page

### DIFF
--- a/src/help/README.md
+++ b/src/help/README.md
@@ -32,5 +32,5 @@ help:
 
 ::: slot center
 ### Need help? We've got your back.
-From common questions to guides, find help for everything Tachiyomi.
+From common questions to guides, find help for everything about Tachiyomi.
 :::


### PR DESCRIPTION
There was a minute error in the ```/help``` page of the tachiyomi website and I tried to correct it.
The original website has ```From common questions to guides, find help for everything Tachiyomi.```
![image](https://user-images.githubusercontent.com/51262281/197397226-4535ee39-b6d2-4a08-9cce-2b82b12d2ead.png)

where as I believe it should have been ```From common questions to guides, find help for everything about Tachiyomi.```
![image](https://user-images.githubusercontent.com/51262281/197397285-caed2f5c-3963-44e7-8df2-435dd78f4b59.png)

That's a small change by me. Hope it helps