### PR TITLE
fix MangaUpdates url

### DIFF
--- a/src/help/guides/tracking.md
+++ b/src/help/guides/tracking.md
@@ -9,7 +9,7 @@ lang: en-US
 
 **Tracking** helps you automatically send read manga chapters to supported trackers, so you can keep track of what and when you read it online.
 
-Tracking is currently supported on [MyAnimeList](https://myanimelist.net), [Anilist](https://anilist.co), [MangaUpdates](mangaupdates.com), [Shikimori](https://shikimori.one), [Bangumi](https://bangumi.tv/), and [Kitsu](https://kitsu.io)
+Tracking is currently supported on [MyAnimeList](https://myanimelist.net), [Anilist](https://anilist.co), [MangaUpdates](https://mangaupdates.com), [Shikimori](https://shikimori.one), [Bangumi](https://bangumi.tv/), and [Kitsu](https://kitsu.io)
 
 - Tracking must be done **manually** for every manga.
 - You must read the last page of a chapter to mark the chapter as read and track it.


### PR DESCRIPTION
Currently it is not an external link.
![image](https://user-images.githubusercontent.com/48650614/198689048-0c36ab38-13d8-43c6-aee6-aeee6cf167e5.png)
