### PR TITLE
Attempt to fix ESlint Errors on Netlify

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ $ npm run build
 $ npm run lint
 ```
 
- **Please make sure to have `npm run build` pass successfully before submitting a PR.** Although the same tests will be run against your PR on the CI server, it is better to have it working locally.
+ **Please make sure to have `npm run test` pass successfully before submitting a PR.** Although the same tests will be run against your PR on the CI server, it is better to have it working locally.
 
 ## Project Structure
 

--- a/package.json
+++ b/package.json
@@ -13,9 +13,10 @@
 	},
 	"homepage": "https://github.com/tachiyomiorg/website#readme",
 	"scripts": {
-		"build": "npm run lint && vuepress build src",
-		"lint": "eslint --fix 'src/.vuepress/**/*.{js,vue}' --no-ignore",
-		"serve": "vuepress dev src"
+		"test": "npm run lint && npm run build",
+		"serve": "vuepress dev src",
+		"build": "vuepress build src",
+		"lint": "eslint --fix \"src/.vuepress/**/*.{js,vue}\" --no-ignore"
 	},
 	"dependencies": {
 		"@mr-hope/vuepress-plugin-sitemap": "1.30.0",


### PR DESCRIPTION
Move `npm run lint` to outside of the `npm run build` script.
Fix ESLint errors Local, same error showing in Netlify console.
Add a new `npm run test` script, replacing the old "lint and build"