### PR TITLE
Add link to FAQ from main troubleshooting page

### DIFF
--- a/website/src/docs/guides/troubleshooting/index.md
+++ b/website/src/docs/guides/troubleshooting/index.md
@@ -6,8 +6,9 @@ description: Facing source or app issues? Here's how to troubleshoot.
 
 # Troubleshooting
 
-Facing source or app issues?
-Here's how to troubleshoot.
+Facing source or app issues? Here's how to troubleshoot.
+
+Be sure to check the [Frequently Asked Questions](/docs/faq/general) for how to address common issues too.
 
 ## WebView
 

--- a/website/src/public/_redirects
+++ b/website/src/public/_redirects
@@ -1,5 +1,5 @@
 # Requested URL -> Redirected URL -> HTTP Code
-/help/                               /                                   301
+/help/                               /docs/guides/troubleshooting/       301
 /help/guides/getting-started/        /docs/guides/getting-started        301
 /help/guides/troubleshooting/        /docs/guides/troubleshooting/       301
 /help/guides/source-migration/       /docs/guides/source-migration       301


### PR DESCRIPTION
To sort of serve as a better replacement for the old `/help` page. This is where users end up when tapping the "Help" item in the "More" screen in the app.