### PR TITLE
Change group name to "dependencies"

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,7 +11,7 @@
 	],
 	"packageRules": [
 		{
-			"groupName": "maintenance",
+			"groupName": "dependencies",
 			"matchUpdateTypes": ["minor", "patch", "pin", "digest"]
 		}
 	],


### PR DESCRIPTION
Minor, but, as the PR title is based off of the group name, it'd feel better if the PR title was "**Update dependencies**" rather than "**Update maintenance**".